### PR TITLE
Admin updates: (toggle/add users) and centerOpenScheduleSchema ;  seed info

### DIFF
--- a/assets/css/adminIndex.css
+++ b/assets/css/adminIndex.css
@@ -1,3 +1,4 @@
+/* Admin:  "Manage Appointments" Page styling*/
 
   .navbar ul {
     list-style: none;         

--- a/assets/css/availabilityIndex.css
+++ b/assets/css/availabilityIndex.css
@@ -1,3 +1,4 @@
+/* Admin:  "Manage Availability" Page styling*/
 
   .navbar ul {
     list-style: none;         

--- a/assets/css/studentIndex.css
+++ b/assets/css/studentIndex.css
@@ -1,3 +1,4 @@
+/* Admin:  "Manage Students" Page styling*/
 
   .navbar ul {
     list-style: none;         
@@ -23,3 +24,42 @@
   .navbar a.active {
     color: #4a148c;            
   }
+
+
+  
+/* When a student's status is changed to inactive, 
+row is greyed out to indicate inactivity*/ 
+  .inactive-row {
+  color: #888;
+  background-color: #f2f2f2;
+}
+
+
+
+/* Modal background */
+.modal {
+  display: none; 
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+/* Modal box */
+.modal-content {
+  background-color: white;
+  margin: 10% auto;
+  padding: 20px;
+  width: 400px;
+  border-radius: 8px;
+}
+
+/* Close button */
+.close-btn {
+  float: right;
+  font-size: 20px;
+  cursor: pointer;
+}

--- a/assets/css/tutorIndex.css
+++ b/assets/css/tutorIndex.css
@@ -1,3 +1,5 @@
+/* Admin:  "Manage Tutors" Page styling*/
+
 
   .navbar ul {
     list-style: none;         
@@ -25,8 +27,42 @@
   }
 
 
-
+/* When a tutor's status is changed to inactive, 
+row is greyed out to indicate inactivity*/ 
   .inactive-row {
   color: #888;
   background-color: #f2f2f2;
+}
+
+
+
+/* Copied from student Modal code, same styling */
+/* will be updated/changed later */
+
+/* Modal background */
+.modal {
+  display: none; 
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+/* Modal box */
+.modal-content {
+  background-color: white;
+  margin: 10% auto;
+  padding: 20px;
+  width: 400px;
+  border-radius: 8px;
+}
+
+/* Close button */
+.close-btn {
+  float: right;
+  font-size: 20px;
+  cursor: pointer;
 }

--- a/assets/js/studentIndex.js
+++ b/assets/js/studentIndex.js
@@ -1,52 +1,34 @@
+// Search entire row text
+const search = document.getElementById("search");
 
-    // Search entire row text
-    const search = document.getElementById("search");
+search.addEventListener("input", () => {
+  const q = search.value.toLowerCase();
 
-    search.addEventListener("input", () => {
-      const q = search.value.toLowerCase();
-
-      document.querySelectorAll("#tutorRows tr").forEach(row => {
-        row.style.display = row.textContent.toLowerCase().includes(q)
-          ? ""
-          : "none";
-      });
-    });
-
-
-
-
-
-
-const toggleActiveBtn = document.getElementById("toggleActiveBtn");
-
-toggleActiveBtn.addEventListener("click", () => {
-
-  const checkedRows = Array.from(document.querySelectorAll("#tutorRows tr"))
-    .filter(tr => tr.querySelector(".rowCheck")?.checked);
-
-  // If nothing selected
-  if (checkedRows.length === 0) {
-    alert("Please select at least one student to toggle active status.");
-    return;
-  }
-
-  // Confirmation popup
-  const ok = confirm(
-    `Are you sure you want to toggle the active status for ${checkedRows.length} student(s)?`
-  );
-
-  if (!ok) return; // if they click Cancel, stop here
-
-  // Toggle Yes <-> No
-  checkedRows.forEach(tr => {
-    const cells = tr.querySelectorAll("td");
-    const activeCell = cells[4];
-
-    const current = activeCell.textContent.trim().toLowerCase();
-
-    activeCell.textContent = (current === "yes") ? "No" : "Yes";
-
-    // optional: uncheck after toggling
-    tr.querySelector(".rowCheck").checked = false;
+  document.querySelectorAll("#studentRows tr").forEach(row => {
+    row.style.display = row.textContent.toLowerCase().includes(q)
+      ? ""
+      : "none";
   });
+});
+
+const openBtn = document.getElementById("openAddStudentModal");
+const modal = document.getElementById("addStudentModal");
+const closeBtn = document.getElementById("closeAddStudentModal");
+
+// Open the modal when the "Add User" button is clicked 
+// sidenote, will change to "Add Student" for separate page views
+openBtn.addEventListener("click", () => {
+  modal.style.display = "block";
+});
+
+// Close the modal when the X button is clicked
+closeBtn.addEventListener("click", () => {
+  modal.style.display = "none";
+});
+
+// Also^^^ close modal if user clicks outside of the modal box 
+window.addEventListener("click", (e) => {
+  if (e.target === modal) {
+    modal.style.display = "none";
+  }
 });

--- a/assets/js/tutorIndex.js
+++ b/assets/js/tutorIndex.js
@@ -1,53 +1,35 @@
+const search = document.getElementById("search");
 
-    // Search entire row text
-    const search = document.getElementById("search");
+search.addEventListener("input", () => {
+  const q = search.value.toLowerCase();
 
-    search.addEventListener("input", () => {
-      const q = search.value.toLowerCase();
-
-      document.querySelectorAll("#tutorRows tr").forEach(row => {
-        row.style.display = row.textContent.toLowerCase().includes(q)
-          ? ""
-          : "none";
-      });
-    });
-
-
-    
-
-
-
-
-const toggleActiveBtn = document.getElementById("toggleActiveBtn");
-
-toggleActiveBtn.addEventListener("click", () => {
-
-  const checkedRows = Array.from(document.querySelectorAll("#tutorRows tr"))
-    .filter(tr => tr.querySelector(".rowCheck")?.checked);
-
-  // If nothing selected
-  if (checkedRows.length === 0) {
-    alert("Please select at least one student to toggle active status.");
-    return;
-  }
-
-  // Confirmation popup
-  const ok = confirm(
-    `Are you sure you want to toggle the active status for ${checkedRows.length} student(s)?`
-  );
-
-  if (!ok) return; // if they click Cancel, stop here
-
-  // Toggle Yes <-> No
-  checkedRows.forEach(tr => {
-    const cells = tr.querySelectorAll("td");
-    const activeCell = cells[4];
-
-    const current = activeCell.textContent.trim().toLowerCase();
-
-    activeCell.textContent = (current === "yes") ? "No" : "Yes";
-
-    // optional: uncheck after toggling
-    tr.querySelector(".rowCheck").checked = false;
+  document.querySelectorAll("#tutorRows tr").forEach(row => {
+    row.style.display = row.textContent.toLowerCase().includes(q)
+      ? ""
+      : "none";
   });
+});
+
+
+
+
+
+// retrieving the addTutorModal box & open/close buttons
+const addTutorModal = document.getElementById("addTutorModal");
+const openAddTutorModal = document.getElementById("openAddTutorModal");
+const closeAddTutorModal = document.getElementById("closeAddTutorModal");
+// opening (display) the modal when clicking on "Add Tutor"
+openAddTutorModal.addEventListener("click", () => {
+  addTutorModal.style.display = "block";
+});
+// closing ("none" for display) the modal when clicking the x 
+closeAddTutorModal.addEventListener("click", () => {
+  addTutorModal.style.display = "none";
+});
+// when click on addTutorModal (NOT the content box), display gets set 
+// to none (when clicking anywhere outside of content box)
+window.addEventListener("click", (event) => {
+  if (event.target === addTutorModal) {
+    addTutorModal.style.display = "none";
+  }
 });

--- a/server.js
+++ b/server.js
@@ -3,6 +3,8 @@ const dotenv = require("dotenv");
 const morgan = require("morgan");
 const connectMongo = require("./server/database/connect");
 const session = require('express-session'); // allows us to store session tokens (logging into Google Calendar)
+// 
+const seedOpenCenter = require("./server/seed/seedOpenCenter");
 
 dotenv.config();
 
@@ -135,6 +137,24 @@ app.get('/seed', async (req, res) => {
         res.send('Seeding failed: ' + err.message);
     }
 });
+
+
+// TEMPORARY: seed baseline center hours
+// Visit -> http://localhost:3000/seedCenter
+// After first run → inserts 7 weekday records
+// On later visits → should log "Center hours already exist", check terminal for "Center hours already exist" message!!
+// I used mongosh to double-check, all weekdays correctly inserted from seedOpenCenter.js, terminal 
+// showed "Center hours already exit" after visiting url 2+ times, used db.centeropens.countDocuments() = 7 
+app.get('/seedCenter', async (req, res) => {
+    try {
+        await seedOpenCenter();
+        res.send('Center hours seeded successfully!');
+    } catch (err) {
+        console.error(err);
+        res.send('Seeding failed: ' + err.message);
+    }
+});
+
 
 // connect to the database
 connectMongo();

--- a/server/controller/adminController.js
+++ b/server/controller/adminController.js
@@ -90,6 +90,9 @@ exports.getAdminTutorIndex = async (req, res) => {
   try {
     // finding tutors in user collection
     const tutors = await User.find({ role: "tutor" });
+    // retrieving courses (for when admin adds a tutor, they need to select the course(s) tutor will teach)
+const courses = await Course.find();
+
 
     // open adminTutorIndex view
     res.render("adminTutorIndex", {
@@ -99,7 +102,9 @@ exports.getAdminTutorIndex = async (req, res) => {
       jsFile: "tutorIndex.js",
       user: { role: "admin" },
       // passing list of tutors into view
-      tutors: tutors
+      tutors: tutors,
+      // passing courses into view 
+      courses: courses
     });
   } catch (err) {
     // prints erroe to console
@@ -120,7 +125,6 @@ exports.getAdminTutorIndex = async (req, res) => {
 
 
 // Changing a tutor's status from active to inactive or vice versa
-
 exports.toggleTutorStatus = async (req, res) => {
   try {
     // retrieving selected tutor ID from submitted form (selected Tutor)
@@ -169,15 +173,165 @@ exports.toggleTutorStatus = async (req, res) => {
 
 
 // renders admin student index
-exports.getAdminStudentIndex = (req, res) => {
-    res.render('adminStudentIndex', 
+exports.getAdminStudentIndex = async(req, res) => {
+
+try {
+  // retrieving students from user collection
+  const students = await User.find({role: "student"});
+ res.render("adminStudentIndex", 
         {
             error: null,
-            title: 'Admin Manage Students',
-            cssStylesheet: 'studentIndex.css',
-            jsFile: 'studentIndex.js',
-            user: { role: 'admin' } // TEMPORARY PLACE HOLDER
-            // eventually we will replace this with a real user, like: req.session.user
+            title: "Admin Manage Students",
+            cssStylesheet: "studentIndex.css",
+            jsFile: "studentIndex.js",
+            user: { role: "admin" }, 
+            // pass list of students into view 
+            students: students
     });
+} catch (err){
+  res.render("adminStudentIndex", 
+{
+  error: "Could not load students",
+  title: "Admin Manage Students",
+            cssStylesheet: "studentIndex.css",
+            jsFile: "studentIndex.js",
+            user: { role: "admin" },
+            // empty array when error occurs
+            students: []
+}
+)}
+
 };
 
+
+
+
+
+
+
+// Changing a student's status from active to inactive or vice versa
+exports.toggleStudentStatus = async (req, res) => {
+  try {
+    // retrieving selected student ID from submitted form (this is from the radio button "SelectedStudent")
+    const studentId = req.body.selectedStudent;
+
+    // if a student is not selected (no Id retrived), re-render page -> makes sure undefined id's are updated
+    if (!studentId) {
+      const students = await User.find({ role: "student" });
+
+      return res.render("adminStudentIndex", {
+        error: "Please select a student first.",
+        title: "Admin Manage Students",
+        cssStylesheet: "studentIndex.css",
+        jsFile: "studentIndex.js",
+        user: { role: "admin" },
+        students: students
+      });
+    }
+
+    // findin gthe selected user (student) by their id and role
+    const student = await User.findOne({
+      _id: studentId,
+      role: "student"
+    });
+
+    // Makes sure student exists in db 
+    if (!student) {
+      return res.status(404).send("Student not found.");
+    }
+
+    // Toggle the students isActive value / update it
+    await User.updateOne(
+      { _id: studentId, role: "student" },
+      { $set: { isActive: !student.isActive } }
+    );
+
+    // re-renders updated list (active vs. inactive) and redirects to the manage students page
+    res.redirect("/adminStudentIndex");
+
+  } 
+    // in case of any erros, can log them and 500 for unfulfilled req 
+
+  catch (err) {
+    console.error(err);
+    res.status(500).send("Could not update student status.");
+  }
+};
+
+
+
+
+// Function to control ADDINg new user (student/tutor)from admnin
+exports.addUser = async (req, res) => {
+  try {
+    // get data from what was entered in the modal
+    const { fname, lname, email, password, role } = req.body;
+    // 
+    let { tutorCourses } = req.body;
+
+    // make sure all fields were filled out
+    if (!fname || !lname || !email || !password || !role) {
+      return res.status(400).send("All fields are required.");
+    }
+
+    // Admin can only assign students and students, 
+    // if we need to change to add another admin this is just temporary for now
+    if (role !== "student" && role !== "tutor") {
+      return res.status(400).send("Invalid role.");
+    }
+
+    // Security check to make sure that emails will not be dupliated 
+    // (if a diff user already has email, return the 400/cannot process req)
+    const existingUser = await User.findOne({ email: email });
+    if (existingUser) {
+      return res.status(400).send("A user with that email already exists.");
+    }
+
+
+
+    // if there is no tutor course selected when filling out "Add Tutor", 
+    // then 400/cannot process req is sent and that at least one course must be selected
+    if(role == "tutor"){
+      if(!tutorCourses){
+        return res.status(400).send("Course(s) must be selected to add a tutor")
+      }
+   
+      // making sure selected course(s) is turned into an array bc model expects 
+      // tutorCourses to be an array
+if (!Array.isArray(tutorCourses)) {
+  tutorCourses = [tutorCourses];
+}
+
+ }
+ else {
+  // students don't have tutor courses
+  tutorCourses = [];
+ }
+
+    // when all above is passed/checked, create the new user 
+    await User.create({
+      fname: fname,
+      lname: lname,
+      email: email,
+      passwordHash: password,
+      role: role,
+      isActive: true,
+      tutorCourses: tutorCourses
+    });
+
+    // redirect back to the correct page after creating the user
+    if (role === "student") {
+      return res.redirect("/adminStudentIndex");
+    } 
+    // I only have the "Add User" for students right now, adding tutor very soon
+    else {
+      return res.redirect("/adminTutorIndex");
+    }
+
+  } 
+  // in case of any erros, can log them and 500 for unfulfilled req 
+  catch (err) {
+    console.error(err);
+    res.status(500).send("Could not add user.");
+  }
+};

--- a/server/model/centerOpenSchedule.js
+++ b/server/model/centerOpenSchedule.js
@@ -1,0 +1,21 @@
+const mongoose = require("mongoose");
+
+
+const centerOpenScheduleSchema = new mongoose.Schema({
+    // storing weekday name, “unique” for 7 total documents, no duplicates of baseline
+    weekday: {type: String, enum: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"], 
+    required: true, unique: true},
+
+    isClosed: {type: Boolean, default: false},
+
+    // the openTime is required only IF center is not closed 
+// ex: if isClosed === true for Saturday, then !this.isClosed = false, so openTime is not required
+// SAME LOGIC for close time
+    openTime: {type: String,required: function () {return !this.isClosed;}},
+    closeTime: {type: String,required: function () {return !this.isClosed;}},
+},
+
+{timestamps: true}
+)
+
+module.exports = mongoose.model("CenterOpen", centerOpenScheduleSchema);

--- a/server/routes/adminRoute.js
+++ b/server/routes/adminRoute.js
@@ -8,7 +8,7 @@ route.get('/adminIndex', controller.getAdminIndex);
 
 // renders adminAvailabilityIndex
 route.get('/adminAvailabilityIndex', controller.getAdminAvailabilityIndex);
-// (re)Renders adminTutorIndex when tutor active status is toggled
+// Receives POST request to toggle tutor active status
 route.post("/adminTutorIndex/toggle", controller.toggleTutorStatus);
 
 
@@ -18,5 +18,13 @@ route.get('/adminTutorIndex', controller.getAdminTutorIndex);
 
 // renders adminStudentIndex
 route.get('/adminStudentIndex', controller.getAdminStudentIndex);
+
+// Receives POST request to toggle student active status
+route.post("/adminStudentIndex/toggle", controller.toggleStudentStatus);
+
+// Handles form submission to create a new user (student or tutor)
+route.post("/adminUsers/add", controller.addUser);
+
+
 
 module.exports = route;

--- a/server/seed/seedOpenCenter.js
+++ b/server/seed/seedOpenCenter.js
@@ -1,0 +1,31 @@
+const CenterOpen = require("../model/centerOpenSchedule");
+
+async function seedOpenSchedule() {
+  try{
+  const existingMonday = await CenterOpen.findOne({ weekday: "Monday" });
+
+  if (!existingMonday) {
+    await CenterOpen.insertMany([
+      // This is modeled directly off of this site https://itk.ilstu.edu/it168/html/Debugging%20Schedule.html 
+      // for tutoring hours; Mon/Wed open 1pm-7pm  |  Tue/Thur/Fri open 11am-6pm
+      // build of baseline 
+      { weekday: "Sunday", isClosed: true },
+      { weekday: "Monday", isClosed: false, openTime: "13:00", closeTime: "19:00" },
+      { weekday: "Tuesday", isClosed: false, openTime: "11:00", closeTime: "18:00" },
+      { weekday: "Wednesday", isClosed: false, openTime: "13:00", closeTime: "19:00" },
+      { weekday: "Thursday", isClosed: false, openTime: "11:00", closeTime: "18:00" },
+      { weekday: "Friday", isClosed: false, openTime: "11:00", closeTime: "18:00" },
+      { weekday: "Saturday", isClosed: true }
+    ]);
+
+    console.log("Default center hours inserted.");
+  } else {
+    console.log("Center hours already exist.");
+  }
+} // end of try
+ catch(err){
+      console.error("Error seeding center hours:", err.message);
+}
+} // end of seedOpenSchedule func
+
+module.exports = seedOpenSchedule;

--- a/views/adminIndex.ejs
+++ b/views/adminIndex.ejs
@@ -14,50 +14,11 @@
 
 
   <!-- Appointment/cancellation buttons -->
-  <button type="button" id="addBtn">Add Appointment</button>
   <button type="button" id="cancelBtn">Cancel Appointment</button>
   <button type="button" id="historyBtn">Cancellation History</button>
-  <button type="button" id="assignTutorBtn">Assign Tutor</button>
 
-
-  <!-- Adding Appointments form -->
-
-  <!-- Form appears when "Add Appointment" is clicked-->
-<form id="addForm" action="/adminIndex/findTutors" method="GET" style="display:none; margin-top:10px;">
-  <input name="studentFName" type="text" placeholder="Student First Name" required>
-  <input name="studentLName" type="text" placeholder="Student Last Name" required>
-  <input name="date" type="date" required>
-  <input name="time" type="time" required>
-
- <!-- Course dropdown (dynamically populated from db!)-->
-  <select name="course" required>
-    <!--default placeholder of courses-->
-  <option value="" disabled selected>Select Course</option>
-  <!-- Looping through course array (passed from cont.)-->
-  <% courses.forEach(course => { %>
-    <!-- passing each course as an option (in dropdown menu)-->
-     <!-- note to self, value = course's db id-->
-  <option value="<%= course._id %>"><%= course.courseName %></option>
-<% }) %>
-</select>
-
-  <button type="submit">Find Tutors</button>
-</form>
-
-
-<!-- AFTER SUBMISSION (clicking the "Find Tutors" button above)
- A DROPDOWN SHOULD BE POPULATED showing all tutors available 
- to be assigned to the chosen appointment (and/or showing that selected appointment 
- is not valid/all tutors are not available during selected appointment range?) 
- If appointment range is valid, admin should then choose a tutor from dropdown 
- and click a final "save" button which adds/creates appointment-->
-    </select>
-
-    <button type="submit">Save</button>
-  </form>
 
   <br><br>
-
 
 
 

--- a/views/adminStudentIndex.ejs
+++ b/views/adminStudentIndex.ejs
@@ -11,44 +11,90 @@
  
   <br>
 
+  <form action="/adminStudentIndex/toggle" method="POST">
+
   <!-- Search -->
   <input type="text" id="search" placeholder="Search students..." />
+<!-- toggle student status (active vs. inactive) button-->
+  <button type="submit" id="toggleActiveBtn">Toggle Active</button>
+<!-- Add user (student) button -> opens Modal-->
+  <button type="button" id="openAddStudentModal">Add Student</button>
 
-  <button type="button" id="toggleActiveBtn">Toggle Active</button>
 <br><br>
 
 
 
 
 
-  <!-- Tutors Table -->
+  <!-- Students Table -->
   <table border="1" cellpadding="6" cellspacing="0">
     <thead>
       <tr>
         <th>Select</th>
-        <th>ID</th>
         <th>Name</th>
         <th>Email</th>
         <th>Active</th>
       </tr>
     </thead>
 
-    <tbody id="tutorRows">
-      <tr>
-        <td><input type="checkbox" class="rowCheck"></td>
-        <td>1</td>
-        <td>student 1</td>
-        <td>stu1@ilstu.edu</td>
-        <td>Yes</td>
-      </tr>
-      <tr>
-        <td><input type="checkbox" class="rowCheck"></td>
-        <td>2</td>
-        <td>student 2</td>
-        <td>stu2@ilstu.edu</td>
-        <td>No</td>
-      </tr>
+<!-- Loop through student array (from adminController)-->
+    <tbody id="studentRows">
+       <% students.forEach(student => { %>
+        <!-- use no class (' ') if student is active, use 'inactive-row' styling if student is not active-->
+         <tr class="<%= student.isActive ? '' : 'inactive-row' %>">
+<!-- creates a radio button per student for selection (to edit student status as inactive/actvie)-->
+          <td>
+            <input type="radio" name="selectedStudent" value="<%= student._id %>">
+          </td>
+          <td><%= student.fname %> <%= student.lname %></td>
+          <td><%= student.email %></td>
+          <!-- prints student's status based on isActive -->
+          <td><%= student.isActive ? "Yes" : "No" %></td>
+        </tr>
+      <% }) %>
     </tbody>
   </table>
+
+
+  </form>
+
+
+  <!-- "Add Student" Modal -> form to create/Add new student to db  -->
+   <!-- pop-up container-->
+<div id="addStudentModal" class="modal">
+  <!-- content box (temp white)-->
+  <div class="modal-content">
+    <!-- x to close modal-->
+    <span class="close-btn" id="closeAddStudentModal">&times;</span>
+
+    <h2>Add Student</h2>
+<!-- connected to route, sends data to /adminUsers/add, POST req for submission-->
+    <form action="/adminUsers/add" method="POST">
+      <!-- data to be sent (first name, last name, email, password (We can just have it as a 
+       temporary password set by admin for students to use to login and then student can change password after
+       / be sent a link to change password? ) )-->
+      <input type="hidden" name="role" value="student">
+      <label>First Name:</label>
+  <input type="text" name="fname" required>
+      <br><br>
+
+      <label>Last Name:</label>
+     <input type="text" name="lname" required>
+      <br><br>
+
+      <label>Email:</label>
+      <input type="email" name="email" required>
+    <br><br>
+      <label>Password:</label>
+      <input type="text" name="password" required>
+
+      <br><br>
+      <button type="submit">Create Student</button>
+    </form>
+  </div>
+</div>
+
+
+
 
 <%- include("includes/_footer") %>

--- a/views/adminTutorIndex.ejs
+++ b/views/adminTutorIndex.ejs
@@ -18,6 +18,9 @@
 
   <button type="submit">Toggle Active</button>
 
+  <!-- Add tutor button -> opens Modal-->
+  <button type="button" id="openAddTutorModal">Add Tutor</button>
+
   <br><br>
 
   <table border="1" cellpadding="6" cellspacing="0">
@@ -46,4 +49,65 @@
   </table>
 
 </form>
+
+
+
+  <!-- "Add Tutor" Modal -> form to create/Add new tutor to db  -->
+   <!-- pop-up container-->
+<div id="addTutorModal" class="modal">
+  <!-- content box (temp white)-->
+  <div class="modal-content">
+    <!-- x to close modal-->
+    <span class="close-btn" id="closeAddTutorModal">&times;</span>
+
+    <h2>Add Tutor</h2>
+<!-- connected to route, sends data to /adminUsers/add, POST req for submission-->
+    <form action="/adminUsers/add" method="POST">
+      <!-- data to be sent (first name, last name, email, password (We can just have it as a 
+       temporary password set by admin for students to use to login and then student can change password after
+       / be sent a link to change password? ) )-->
+      <input type="hidden" name="role" value="tutor">
+      <label>First Name:</label>
+  <input type="text" name="fname" required>
+      <br><br>
+
+      <label>Last Name:</label>
+     <input type="text" name="lname" required>
+      <br><br>
+
+      <label>Email:</label>
+      <input type="email" name="email" required>
+    <br><br>
+      <label>Password:</label>
+      <input type="text" name="password" required>
+
+<!-- a tutor NEEDS to be assigned to at least one course based on User model, 
+ so we need to make sure that when admin creates a tutor, they assign them to the 
+ existing courses from db
+ 
+ so this is a checkbox functionality where admin can select which courses the tutor will 
+ be tutoring students for-->
+<label>Courses:</label><br>
+      <% courses.forEach(course => { %>
+        <label>
+          <input type="checkbox" name="tutorCourses" value="<%= course._id %>">
+         <%= course.courseName %>
+        </label>
+        <br>
+      <% }) %>
+
+
+
+
+
+      <br><br>
+      <button type="submit">Create Tutor</button>
+    </form>
+  </div>
+</div>
+
+
+
+
+
 <%- include("includes/_footer") %>


### PR DESCRIPTION
Hey guys! 

Now, admin can: 
- toggle active/inactive for both students and tutors
- Add a user, both a tutor or student 
- Filtering works correctly on "Manage Appointments", "Manage Tutors", and "Manage Students" page 

Also, I added:
- centerOpenSchedule Schema & created a seed route --> inserts baseline times based on the real tutoring schedule : https://itk.ilstu.edu/it168/html/Debugging%20Schedule.html 
- Verified everything in terminal and mongosh --> double-checked that on first visit to /seedCenter (http://localhost:3000/seedCenter), inserts default times. On 2+visits, logs "you have already inserted center hours"/no duplicates in db centeropens collection! :)

***I also deleted unnecessary buttons/functions such as "Add Appointment" button in admin & some unecessary code for tutorIndex