### PR TITLE
remove tutor name from appointment

### DIFF
--- a/server/controller/studentController.js
+++ b/server/controller/studentController.js
@@ -116,16 +116,16 @@ exports.viewAvailableAppointments = async (req, res) => {
         else {
             // pull shifts that are not booked and on the date and course the user selected
             let availableShifts = await TutorShift.aggregate([
-                { $match: { isBooked: false, shiftDate: { $gte: startOfDay, $lte: endOfDay } } },
-                { $lookup: { from: "users", localField: "tutorId", foreignField: "_id", as: "tutor" } },
+                { $match: { isBooked: false, shiftDate: { $gte: startOfDay, $lte: endOfDay } } }, // filter for unbooked shifts on the selected day
+                { $lookup: { from: "users", localField: "tutorId", foreignField: "_id", as: "tutor" } }, // join with user collection to get tutor details for filtering tutors by course
                 { $unwind: "$tutor" },
-                { $match: { "tutor.tutorCourses": courseId } },
+                { $match: { "tutor.tutorCourses": courseId } }, // filter for tutors that have the user selected course in their tutorCourses array
                 { $lookup: { from: "courses", localField: "tutor.tutorCourses", foreignField: "_id", as: "courses" } },
                 {
-                    $project: {
-                        shiftDate: 1, startTime: 1, endTime: 1, tutorId: "$tutor._id", fname: "$tutor.fname", lname: "$tutor.lname",
+                    $project: { // format result with only necessary details for displaying available shifts - date, start/end time, course name
+                        shiftDate: 1, startTime: 1, endTime: 1,
                         courseName: {
-                            $arrayElemAt: [{
+                            $arrayElemAt: [{ // used to get the courseName from the tutorCourses array that belong to a tutor that matches the courseId selected by the user
                                 $map: {
                                     input: {
                                         $filter: {
@@ -144,9 +144,9 @@ exports.viewAvailableAppointments = async (req, res) => {
                 },
                 { $sort: { shiftDate: 1, startTime: 1 } }
             ]);
-            
-            // console.log("Available shifts:", availableShifts.length);
 
+            // if there are no available shifts for the selected course and day, send an error message and keep the form filled. 
+            // Otherwise, render the page with the available shifts and keep the form filled.
             if (availableShifts.length === 0) {
                 return res.render("studentIndex", {
                     title: "Book an Appointment",

--- a/server/model/tutorShiftModel.js
+++ b/server/model/tutorShiftModel.js
@@ -8,7 +8,6 @@ const tutorShiftSchema = new mongoose.Schema(
         startTime: { type: String, required: true },
         endTime: { type: String, required: true },
         isBooked: { type: Boolean, default: false }
-        // add link to individual tutor google calender??
     },
     { timestamps: true }
 );

--- a/views/studentAppointment.ejs
+++ b/views/studentAppointment.ejs
@@ -25,7 +25,7 @@
                     <p><%= appointment.course %></p>
                     <!--used toUTCString() instead of .toDateString() to get the proper date and slice to look nice-->
                     <p><%= appointment.appointmentDate.toUTCString().slice(0, 16) %></p>
-                    <p><%= appointment.startTime %> - <%= appointment.endTime %></p>
+                    <p><b><%= appointment.startTime %> - <%= appointment.endTime %></b></p>
                 </div>
             <% }) %>
         <% } %>

--- a/views/studentIndex.ejs
+++ b/views/studentIndex.ejs
@@ -23,7 +23,7 @@
                             <% }) %>
                         </select><br/><br/>
                         <label for="selectDay">Select a Day:</label>
-                        <input type="date" id="selectDay" name="selectDay" value="<%= form ? form.selectDay : '' %>" required><br/><br/>
+                        <input type="date" id="selectDay" name="selectDay" value="<%= form ? form.selectDay : '' %>" min = "<%= new Date().toISOString().split('T')[0] %>" required><br/><br/>
                         <button id="viewAppointments" type="submit">View Available Appointments</button>
                         <% if (error) { %>
                             <br/><br/>
@@ -44,11 +44,10 @@
                                     <input type="hidden" name="tutorShiftId" value="<%= shift._id %>">
                                     <input type="hidden" name="course" value="<%= shift.courseName %>">
 
-                                    <p><strong><%= shift.fname %> <%= shift.lname %></strong></p>
                                     <p><%= shift.courseName %></p>
                                     <!--used toUTCString() instead of .toDateString() to get the proper date and slice to look nice-->
                                     <p><%= shift.shiftDate.toUTCString().slice(0, 16) %></p>
-                                    <p><%= shift.startTime %> - <%= shift.endTime %></p>
+                                    <p><b><%= shift.startTime %> - <%= shift.endTime %></b></p>
                                     <button type="submit">Book</button>
                                 </form>
                             </div>

--- a/views/tutorIndex.ejs
+++ b/views/tutorIndex.ejs
@@ -79,7 +79,7 @@
                     <p><%= appointment.course %></p>
                     <!--used toUTCString() instead of .toDateString() to get the proper date and slice to look nice-->
                     <p><%= appointment.appointmentDate.toUTCString().slice(0, 16) %></p>
-                    <p><%= appointment.startTime %> - <%= appointment.endTime %></p>
+                    <p><b><%= appointment.startTime %> - <%= appointment.endTime %></b></p>
                     <p><%= appointment.appointmentStatus %></p>
                     <br />
                 </div>


### PR DESCRIPTION
Removed tutor name when students view appointment availability. Currently if multiple tutors are assigned for that date and time and can teach that course, there will be multiple appointments to choose from that look that same. In the future this will be changed. Start/end times are now bolded to improve readability. Picking a date is now restricted on frontend and backend to not allow past dates to be chosen.  