### PR TITLE
Jp restrict general hours

### DIFF
--- a/assets/js/adminAvailability.js
+++ b/assets/js/adminAvailability.js
@@ -1,6 +1,9 @@
 const editHoursButton = document.getElementById("editHoursButton");
 const editHoursForm = document.getElementById("changeHoursForm");
 const submitHoursButton = document.getElementById("submitHoursButton");
+const centerOpenTimeInput = document.getElementById("centerOpenTime");
+const centerCloseTimeInput = document.getElementById("centerCloseTime");
+const closeWeekdayDropdown = document.getElementById("closeWeekdayDropdown");
 
 // When editHours button is clicked
 editHoursButton.addEventListener("click", () => {
@@ -8,8 +11,34 @@ editHoursButton.addEventListener("click", () => {
   editHoursForm.style.display = (editHoursForm.style.display === "none") ? "block" : "none";
 });
 
-// When submitHours button is clicked
-submitHoursButton.addEventListener("click", () => {
-  // form hidden, show -> otherwise, default non-display
-  editHoursForm.style.display = (editHoursForm.style.display === "none") ? "block" : "none";
+// Hide form when submit occurs
+editHoursForm.addEventListener("submit", () => {
+  editHoursForm.style.display = "none";
+});
+
+// Input minutes change to 00 when admin enters open time
+centerOpenTimeInput.addEventListener("change", () => {
+  if (centerOpenTimeInput.value) {
+    const openTimeSplit = centerOpenTimeInput.value.split(":");
+    centerOpenTimeInput.value = `${openTimeSplit[0]}:00`;
+  }
+});
+
+// Input minutes change to 00 when admin enters close time
+centerCloseTimeInput.addEventListener("change", () => {
+  if (centerCloseTimeInput.value) {
+    const closeTimeSplit = centerCloseTimeInput.value.split(":");
+    centerCloseTimeInput.value = `${closeTimeSplit[0]}:00`;
+  }
+});
+
+// Open and close time cannot be entered if closeWeekdayDropdown is set to "Yes"
+closeWeekdayDropdown.addEventListener("change", () => {
+  if (closeWeekdayDropdown.value === "Yes") {
+    centerOpenTimeInput.disabled = true;
+    centerCloseTimeInput.disabled = true;
+  } else {
+    centerOpenTimeInput.disabled = false;
+    centerCloseTimeInput.disabled = false;
+  }
 });

--- a/server/controller/adminController.js
+++ b/server/controller/adminController.js
@@ -103,7 +103,7 @@ exports.getAdminIndex = async (req, res) => {
 // -------------------------------------------------------------------------------------------
 
 // renders ADMIN AVAILABILITY INDEX
-exports.getAdminAvailabilityIndex = (req, res) => {
+exports.getAdminAvailabilityIndex = async (req, res) => {
   try{
 
   // if not an auth user, send to login page
@@ -129,25 +129,30 @@ exports.getAdminAvailabilityIndex = (req, res) => {
             user: null
         });
       }
-  res.render('adminAvailabilityIndex',
-    {
-      error: null,
-      title: 'Admin Availability',
-      cssStylesheet: 'availabilityIndex.css',
-      jsFile: 'adminAvailability.js', // will have js for this page at some point
-      user: req.session.user
-    });
-} catch(err){
-   res.render('adminAvailabilityIndex',
-    {
-      error: "Could not load page",
-      title: 'Admin Availability',
-      cssStylesheet: 'availabilityIndex.css',
-      jsFile: null, // will have js for this page at some point
-      user: req.session.user
-    });
+
+      const weekdays = await centerOpen.find();
+
+      res.render('adminAvailabilityIndex',
+      {
+        error: null,
+        title: 'Admin Availability',
+        cssStylesheet: 'availabilityIndex.css',
+        jsFile: 'adminAvailability.js',
+        user: req.session.user,
+        weekdays
+      });
+    } catch(err){
+      res.render('adminAvailabilityIndex',
+      {
+        error: "Could not load page",
+        title: 'Admin Availability',
+        cssStylesheet: 'availabilityIndex.css',
+        jsFile: 'adminAvailability.js',
+        user: req.session.user,
+        weekdays
+      });
+    }
 }
-  }
 
 // -------------------------------------------------------------------------------------------
 
@@ -1034,7 +1039,7 @@ exports.addUser = async (req, res) => {
     const saltRounds = 10;
     const passwordHash = await bcrypt.hash(password, saltRounds);
 
-    // when all above is passed/checked, create the new user                                                                 !!
+    // when all above is passed/checked, create the new user
     await User.create({
       fname: fname,
       lname: lname,
@@ -1092,38 +1097,83 @@ exports.changeHours = async (req, res) => {
         });
       }
       
-    const { weekday, centerOpenTime, centerCloseTime } = req.body;
+    const { weekday, centerOpenTime, centerCloseTime, closeWeekdayDropdown } = req.body;
 
-    // make sure all fields were filled out
-    if (!weekday || !centerOpenTime || !centerCloseTime) {
-      return res.status(400).send("All fields are required.");
+    let weekdays = await centerOpen.find();
+
+    // make sure all required fields were filled out if weekday is set to open
+    if ((!weekday || !centerOpenTime || !centerCloseTime) && closeWeekdayDropdown === "No") {
+      return res.render('adminAvailabilityIndex', {
+        error: "All fields are required.",
+        title: 'Admin Availability',
+        cssStylesheet: 'availabilityIndex.css',
+        jsFile: 'adminAvailability.js',
+        user: req.session.user,
+        weekdays
+      });
     }
 
-    const openHour = Number(centerOpenTime.split(":")[0]); // Get open hour as an integer
-    const closeHour = Number(centerCloseTime.split(":")[0]); // Get close hour as an integer
-    const openMinute = Number(centerOpenTime.split(":")[1]); // Get open minute as an integer
-    const closeMinute = Number(centerCloseTime.split(":")[1]); // Get close minute as an integer
+    // if closeWeekdayDropdown is set to "Yes", then set the specified weekday to closed
+    if (closeWeekdayDropdown === "Yes") {
+      await centerOpen.findOneAndUpdate({ weekday: weekday }, { $set: { isClosed: true } });
+    } else { // otherwise, set hours for specified weekday and set isClosed to false
+      const openHour = Number(centerOpenTime.split(":")[0]); // Get open hour as an integer
+      const closeHour = Number(centerCloseTime.split(":")[0]); // Get close hour as an integer
+      const openMinute = Number(centerOpenTime.split(":")[1]); // Get open minute as an integer
+      const closeMinute = Number(centerCloseTime.split(":")[1]); // Get close minute as an integer
     
-    // make sure entered start time is less than entered end time
-    if (openHour > closeHour) {
-      return res.status(400).send("Open Time must be earlier than Close Time.");
+      // make sure minutes are set to 00
+      if (openMinute !== 0 || closeMinute !== 0) {
+        return res.render('adminAvailabilityIndex', {
+          error: "Minutes must be 00. Please enter on the hour mark only.",
+          title: 'Admin Availability',
+          cssStylesheet: 'availabilityIndex.css',
+          jsFile: 'adminAvailability.js',
+          user: req.session.user,
+          weekdays
+        });
+      }
+
+      // make sure entered start time is less than entered end time
+      if (openHour > closeHour) {
+        return res.render('adminAvailabilityIndex', {
+          error: "Open Time must be earlier than Close Time.",
+          title: 'Admin Availability',
+          cssStylesheet: 'availabilityIndex.css',
+          jsFile: 'adminAvailability.js',
+          user: req.session.user,
+          weekdays
+        });
+      }
+
+      // make sure center hours cannot be set to the same time
+      if (openHour === closeHour) {
+        return res.render('adminAvailabilityIndex', {
+          error: "Cannot set equal open time and close time.",
+          title: 'Admin Availability',
+          cssStylesheet: 'availabilityIndex.css',
+          jsFile: 'adminAvailability.js',
+          user: req.session.user,
+          weekdays
+        });
+      }
+
+      // update MongoDB with new times and set isClosed to false
+      await centerOpen.findOneAndUpdate({ weekday: weekday }, { $set: { isClosed: false ,openTime: centerOpenTime, closeTime: centerCloseTime} });
     }
 
-    // if center hours set to less than one-hour difference, then close the day
-    if (((closeHour * 60 + closeMinute)-(openHour * 60 + openMinute)) < 60) {
-      await centerOpen.findOneAndUpdate({weekday: weekday}, { $set: { openTime: centerOpenTime, closeTime: centerCloseTime, isClosed: true } });
-    } else { // otherwise, update the weekday open and close hours, open the day
-      await centerOpen.findOneAndUpdate({weekday: weekday}, { $set: { openTime: centerOpenTime, closeTime: centerCloseTime, isClosed: false } });
-    }
-
+    // get newly updated weekdays
+    weekdays = await centerOpen.find();
+    
     // re-render page once update completes
     res.render('adminAvailabilityIndex', 
     {
       error: null,
       title: 'Admin Availability',
       cssStylesheet: 'availabilityIndex.css',
-      jsFile: 'adminAvailability.js', // will have js for this page at some point
-      user: req.session.user
+      jsFile: 'adminAvailability.js',
+      user: req.session.user,
+      weekdays
     });
   } catch (err) {
     console.log("Change hours failed:", err);
@@ -1132,8 +1182,9 @@ exports.changeHours = async (req, res) => {
       error: 'Failed to change hours.',
       title: 'Admin Availability',
       cssStylesheet: 'availabilityIndex.css',
-      jsFile: 'adminAvailability.js', // will have js for this page at some point
-      user: req.session.user
+      jsFile: 'adminAvailability.js',
+      user: req.session.user,
+      weekdays
     });
   }
 };

--- a/views/adminAvailabilityIndex.ejs
+++ b/views/adminAvailabilityIndex.ejs
@@ -44,14 +44,18 @@
       <br />
       
       <label id="center-open-label" for="centerOpenTime">Open Time:</label>
-      <input type="time" id="centerOpenTime" name="centerOpenTime" />
+      <input type="time" id="centerOpenTime" name="centerOpenTime" step="3600" />
       <label id="center-close-label" for="centerCloseTime">Close Time:</label>
-      <input type="time" id="centerCloseTime" name="centerCloseTime" />
+      <input type="time" id="centerCloseTime" name="centerCloseTime" step="3600" />
       <br />
-      <strong>Note:</strong> If Open Time and Close Time are set to less than
+      <strong>Note:</strong> On the hour is required to change center hours.
       <br />
-      one hour apart, then the weekday will be set to closed.
-
+      <br />
+      <label id="close-weekday-label" for="closeWeekdayDropdown">Close this day? </label>
+      <select name="closeWeekdayDropdown" id="closeWeekdayDropdown" required >
+        <option value="No">No</option>
+        <option value="Yes">Yes</option>
+      </select>
       <br />
       <br />
 

--- a/views/adminStudentIndex.ejs
+++ b/views/adminStudentIndex.ejs
@@ -86,7 +86,7 @@
       <input type="email" name="email" required>
     <br><br>
       <label>Password:</label>
-      <input type="text" name="password" required>
+      <input type="password" name="password" required>
 
       <br><br>
       <button type="submit">Create Student</button>

--- a/views/adminTutorIndex.ejs
+++ b/views/adminTutorIndex.ejs
@@ -84,7 +84,7 @@
       <input type="email" name="email" required>
     <br><br>
       <label>Password:</label>
-      <input type="text" name="password" required>
+      <input type="password" name="password" required>
 
 <!-- a tutor NEEDS to be assigned to at least one course based on User model, 
  so we need to make sure that when admin creates a tutor, they assign them to the 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -63,8 +63,6 @@
     </div>
 </section>
 
-<!-- Server crashed because HTML comments were used inside <% %> blocks.
-     use // for comments inside ejs js. -->
      <div class = "hoursAndLocation">
     <% 
         // retrieve current date/time to determine if center is currently open or closed
@@ -73,15 +71,18 @@
         // get weekday index from current date (0 = Sunday, 6 = Saturday)
         const weekdayIndex = today.getDay();
 
-        // get current hour and minute
+        // since getDay indexes 0 = Sunday, 6 = Saturday, move the indices around to match the weekdays in application
+        // (this was why open/closed wasn't working originally)
+        const weekdayIndices = [6, 0, 1, 2, 3, 4, 5];
+
+        // get current hour
         const currHour = today.getHours();
-        const currMinute = today.getMinutes();
 
-        // get the matching weekday object from the weekdays array
-        const currWeekday = weekdays[weekdayIndex];
+        // get the matching weekday object from the weekdays array using the proper index for our application weekday order
+        const currWeekday = weekdays[weekdayIndices[weekdayIndex]];
 
-        // declare these first so they can be used outside the if block below
-        let openHour, closeHour, openMinute, closeMinute;
+        // declare open and close hour so they can be used outside the if block below
+        let openHour, closeHour;
 
         // only split/store open and close times if the center is not closed that day
         if (currWeekday && !currWeekday.isClosed) {
@@ -90,18 +91,12 @@
 
             // get close hour as an integer
             closeHour = Number(currWeekday.closeTime.split(":")[0]);
-
-            // get open minute as an integer
-            openMinute = Number(currWeekday.openTime.split(":")[1]);
-
-            // get close minute as an integer
-            closeMinute = Number(currWeekday.closeTime.split(":")[1]);
         }
     %>
 
     <% if (currWeekday && currWeekday.isClosed) { %>
         <h2>We are currently closed!</h2>
-    <% } else if (openHour > currHour || (openHour === currHour && openMinute > currMinute) || closeHour < currHour || (closeHour === currHour && closeMinute <= currMinute)) { %>
+    <% } else if (openHour > currHour || closeHour <= currHour) { %>
         <h2>We are currently closed!</h2>
     <% } else { %>
         <h2>We are currently open!</h2>


### PR DESCRIPTION
Admin cannot set minutes for changing general center hours (defaults back to :00 if try) --> required both frontend and backend validation

Add a closed button where admin can close the weekday and do this without having to enter open and close times

Admin add tutor and student ejs files: changed input type to password instead of text

Open/closed after admin changes hours fix (Note: needed to add weekdays to all the adminAvailabilityIndex rendering in order to function, will need this soon when general center hours will be displayed on this page). Because of previous functionality, our application prefers to have Monday first, but .getDay() for the weekday index prefers Sunday first (index 0). I did not want to accidentally break something somewhere else by changing the application preference to Sunday, so I created weekdayIndices = [6, 0, 1, 2, 3, 4, 5] to easily shift Sunday over (see lines 76-82).