### PR TITLE
Jp tutor add comments

### DIFF
--- a/assets/js/tutorScript.js
+++ b/assets/js/tutorScript.js
@@ -14,19 +14,15 @@ const showButton = document.getElementById("show-button");
 const showSubmitButton = document.getElementById("show-submit-button");
 const showLabel = document.getElementById("show-label");
 const selectShow = document.getElementById("select-show");
+const appointmentRadios = document.querySelectorAll('input[name="selectedAppointment"]');
 
 
-/*
-When select a date on the calendar, the tutor button options for entering data appear.
-These button options do not disappear until you select one of the button options and click submit.
-*/
-shiftDate.addEventListener("change", () => {
-    const selectedDate = shiftDate.value;
-    if (selectedDate) {
-        buttonOptions.style.visibility = "visible";
-    }
+/*Add event listener for each radio button, when change a radio button it makes button options visible*/
+appointmentRadios.forEach(appointmentRadio => {
+  appointmentRadio.addEventListener("change", () => {
+    buttonOptions.style.visibility = "visible";
+  });
 });
-
 
 /*When select Edit / View Comment button on the screen, the comment textarea and submit button appear*/
 addCommentButton.addEventListener("click", ()=> {

--- a/server/controller/tutorController.js
+++ b/server/controller/tutorController.js
@@ -55,7 +55,6 @@ exports.getTutorIndex = async (req, res) => {
         });
 
     } catch (err) {
-        console.error(err);
         res.render('tutorIndex', {
             error: "Failed to load tutor index page.",
             shiftError: null,
@@ -110,7 +109,6 @@ exports.getTutorAppointments = async (req, res) => {
         try {
             tutorShifts = await getTutorShifts(tutorId);
         } catch (err) {
-            console.error("Shift load error:", err);
             shiftError = "Failed to load tutor shifts.";
         }
 
@@ -164,7 +162,6 @@ exports.getTutorAppointments = async (req, res) => {
             pastAppointmentsLoaded: true
         });
     } catch (err) {
-        console.error("Tutor appointment error:", err);
         res.render("tutorIndex", {
             title: "Tutor Appointments",
             cssStylesheet: "tutorStyle.css",
@@ -213,14 +210,128 @@ async function getTutorShifts(theTutorId) {
 
         // if there are no shifts found for the tutor, return an empty array
         if (!tutorShifts || tutorShifts.length === 0) {
-            console.log("No shifts found for tutor.");
             return [];
         }
 
         return tutorShifts;
 
     } catch (err) {
-        console.error(err);
         throw err;
     }
 }
+
+
+// POST: update submitted comment in MongoDB for specific tutor appointment selected
+exports.submitComment = async (req, res) => {
+    try {
+        // if not an auth user, send to login page
+        if (!req.session.user) {
+            return res.render('login',
+            {
+                title: 'Login Page',
+                cssStylesheet: 'login.css',
+                jsFile: null,
+                error: "User not logged in.",
+                user: null
+            });
+        }
+
+        // if auth user but not a tutor, send to login page
+        if (req.session.user.role !== "tutor") {
+            return res.render('login',
+            {
+                title: 'Login Page',
+                cssStylesheet: 'login.css',
+                jsFile: null,
+                error: "Access denied. Only tutors can view this page.",
+                user: null
+            });
+        }
+
+        const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
+        // function to get all shifts for the tutor and sort by date and time
+        let tutorShifts = [];
+        let shiftError = null;
+        try {
+            tutorShifts = await getTutorShifts(tutorId);
+        } catch (err) {
+            shiftError = "Failed to load tutor shifts.";
+        }
+
+        // get appointment id and comments
+        const appointmentId = req.body.selectedAppointment;
+        const comments = req.body['comments-textarea'];
+
+        // no appointment selected
+        if (!appointmentId) {
+            return res.render('tutorIndex', {
+                error: "No appointment selected.",
+                shiftError,
+                title: 'Tutor Appointments',
+                cssStylesheet: 'tutorStyle.css',
+                jsFile: 'tutorScript.js',
+                user: req.session.user,
+                bookedAppointments: [],
+                appointmentsLoaded: false,
+                tutorShifts,
+                pastBookedAppointments: [],
+                pastAppointmentsLoaded: false
+            });
+        }
+
+        // update the comments for specific appointment
+        const appointmentExist = await Appointment.findOneAndUpdate({ _id: appointmentId }, { $set: { tutorComments: comments } });
+
+        // no appointment found
+        if (!appointmentExist) {
+            return res.render('tutorIndex', {
+                error: "Appointment not found.",
+                shiftError,
+                title: 'Tutor Appointments',
+                cssStylesheet: 'tutorStyle.css',
+                jsFile: 'tutorScript.js',
+                user: req.session.user,
+                bookedAppointments: [],
+                appointmentsLoaded: false,
+                tutorShifts,
+                pastBookedAppointments: [],
+                pastAppointmentsLoaded: false
+            });
+        }
+
+        // re-render tutor page
+        res.render('tutorIndex', {
+            error: null,
+            shiftError,
+            title: 'Tutor Appointments',
+            cssStylesheet: 'tutorStyle.css',
+            jsFile: 'tutorScript.js',
+            user: req.session.user,
+            bookedAppointments: [],
+            appointmentsLoaded: false,
+            tutorShifts,
+            pastBookedAppointments: [],
+            pastAppointmentsLoaded: false
+        });
+    } catch (err) {
+        res.render('tutorIndex', {
+            error: "Failed to load tutor index page.",
+            shiftError: null,
+            title: 'Tutor Appointments',
+            cssStylesheet: 'tutorStyle.css',
+            jsFile: 'tutorScript.js',
+            user: req.session.user,
+            bookedAppointments: [],
+            appointmentsLoaded: false,
+            tutorShifts: [],
+            pastBookedAppointments: [],
+            pastAppointmentsLoaded: false
+        });
+    }   
+}
+
+
+// GET: display specific tutor comments in comments text area if any for appointment selected
+// exports.viewComment = async (req, res) => {
+
+// }

--- a/server/routes/tutorRoute.js
+++ b/server/routes/tutorRoute.js
@@ -9,4 +9,10 @@ route.get('/tutorIndex', controller.getTutorIndex);
 // display the tutor's booked appointments
 route.get('/tutorIndex/tutorAppointment', controller.getTutorAppointments);
 
+// update submitted comment in MongoDB for specific tutor appointment selected
+route.post('/tutorIndex/submitComment', controller.submitComment);
+
+// display specific tutor comments in comments text area if any for appointment selected
+// route.get('/tutorIndex/viewComment', controller.viewComment);
+
 module.exports = route;

--- a/views/tutorIndex.ejs
+++ b/views/tutorIndex.ejs
@@ -9,8 +9,8 @@
   <%- include("includes/_navbar") %>
 </header>
 
-    <!--Tutor container for appointment functionality-->
-    <div class="tutor-container">
+  <!--Tutor container for appointment functionality-->
+  <div class="tutor-container">
       <div class="tutor-columns">
         <!-- Tutor's schedule -->
         <div class="tutor-column">
@@ -51,7 +51,7 @@
 
         
 
-        <!--Tutor view appointments column-->
+        <!--Tutor view appointments (upcoming and past) and tutor button features-->
         <div class="tutor-column">
           <h1>Appointments</h1>
           <div id="tutor-view-appointments" class="tutor-view-appointments">
@@ -87,6 +87,9 @@
 
                     <p><%= appointment.appointmentStatus %></p>
                     <br />
+
+                    <input type="radio" name="selectedAppointment" value="<%= appointment._id %>" form="comment-form" />
+
                 </div>
               <% }) %>
             <% } %>
@@ -97,6 +100,55 @@
         <form action="/tutorIndex/tutorAppointment" method="get">
               <button id="viewTutorAppointments" type="submit">View Upcoming and Past Appointments</button>
         </form>
+        <br />
+        <br />
+        <br />
+
+        <!--Tutor feature options-->
+        <div id="tutor-button-options" class="tutor-button-options">
+          <button id="comment-button">Edit / View Comments</button>
+          <br />
+          <button id="time-button">Add Start / End Time</button>
+          <br />
+          <button id="show-button">Show / No-Show</button>
+        </div>
+
+        <!--Tutor feature selections and submit buttons-->
+        <div id="tutor-edit-features" class="tutor-edit-features">
+          <textarea
+            id="comments-textarea"
+            name="comments-textarea"
+            placeholder="Enter tutoring session comments here..."
+            rows="10"
+            cols="50"
+            form="comment-form"
+          ></textarea>
+          <br />
+          <label id="start-time-label" for="session-start-time">Start Time:</label>
+          <input
+            type="time"
+            id="session-start-time"
+            name="session-start-time"
+          />
+          <label id="end-time-label" for="session-end-time">End Time:</label>
+          <input type="time" id="session-end-time" name="session-end-time" />
+          <br />
+          <label id="show-label" for="select-show">Show / No-Show: </label>
+          <select id="select-show" name="select-show">
+            <option value="show">Show</option>
+            <option value="no-show">No-Show</option>
+          </select>
+          <br />
+          <!--Update comment in backend when submit-->
+          <form id="comment-form" action="/tutorIndex/submitComment" method="post">
+            <button id="comment-submit-button" type="submit">
+              Submit Comment
+            </button>
+          </form>
+
+          <button id="time-submit-button" type="submit">Submit Time</button>
+          <button id="show-submit-button" type="submit">Submit Show / No-Show</button>
+        </div>
 
         <!--Tutor view past appointments column-->
         <div class="tutor-column">
@@ -134,6 +186,9 @@
 
                       <p><%= appointment.appointmentStatus %></p>
                       <br />
+
+                      <input type="radio" name="selectedAppointment" value="<%= appointment._id %>" form="comment-form" />
+
                   </div>
                 <% }) %>
               <% } %>
@@ -142,52 +197,6 @@
 
       </div>
     </div>
-  </div>
+  </div> <!-- end of tutor container -->
 
 <%- include("includes/_footer") %>
-
-<!-- This used to be part of the page but is functionality that will be added in the future. This will stay commented out for the time being. -->
- <!-- <label for="selectDay">Select a Day:</label>
-            <input type="date" id="shift-date" name="shift-date" /> -->
-<!--Tutor feature options-->
-        <!-- <div id="tutor-button-options" class="tutor-button-options">
-          <button id="comment-button">Edit / View Comments</button>
-          <br />
-          <button id="time-button">Add Start / End Time</button>
-          <br />
-          <button id="show-button">Show / No-Show</button>
-        </div> -->
-
-        <!--Tutor feature selections and submit buttons-->
-        <!-- <div id="tutor-edit-features" class="tutor-edit-features">
-          <textarea
-            id="comments-textarea"
-            name="comments-textarea"
-            placeholder="Enter tutoring session comments here..."
-            rows="10"
-            cols="50"
-          ></textarea>
-          <br />
-          <label id="start-time-label" for="session-start-time"
-            >Start Time:</label
-          >
-          <input
-            type="time"
-            id="session-start-time"
-            name="session-start-time"
-          />
-          <label id="end-time-label" for="session-end-time">End Time:</label>
-          <input type="time" id="session-end-time" name="session-end-time" />
-          <br />
-          <label id="show-label" for="select-show">Show / No-Show: </label>
-          <select id="select-show" name="select-show">
-            <option value="show">Show</option>
-            <option value="no-show">No-Show</option>
-          </select>
-          <br />
-          <button id="comment-submit-button" type="button">
-            Submit Comment
-          </button>
-          <button id="time-submit-button" type="button">Submit Time</button>
-          <button id="show-submit-button" type="button">Submit Show / No-Show</button>
-        </div> -->


### PR DESCRIPTION
When tutor clicks button to view **upcoming and past appointments,** each appointment displayed now has a radio button. When a radio button is selected, the tutor button features come up. When click the view/edit comments button, the comment box appears and the tutor can submit a comment for that specific appointment and it will update in the backend and using MongoDB (submitComment function). Added some JavaScript to display the tutor button features when a radio button is selected.

There are some commented out things that I will work on another time. The end goal will be when the tutor selects the view/edit comments button after selecting a specific appointment radio button, the previous comment for that specific appointment currently stored in MongoDB will load in the comments textarea. From there, the tutor can either resubmit that or edit the comment and it will update in the database after the tutor submits.