### PR TITLE
AC_AdminOAuth

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,15 +20,16 @@ const { connect } = require("http2"); // not being used currently
 // Logging
 app.use(morgan("tiny"));
 
-// --- Google Calendar API Session Management ---
-// A session allows our server to remember things about a user between requests
-// In this case, it'll store the user's Google OAuth tokens so they STAY authenticated
-// as they move around our web app.
+// --- Login Sessions ---
 app.use(
   session({
     secret: process.env.SESSION_SECRET,
     resave: false,
-    saveUninitialized: true,
+    saveUninitialized: false, // session begins once user logs in, not before
+    rolling: true, // resets our maxAge timer whenever a user is actively using our website (making requests)
+    cookie: {
+      maxAge: 1000 * 60 * 30 // 30 minutes in milliseconds
+    }
   }),
 );
 

--- a/server/config/googleAuth.js
+++ b/server/config/googleAuth.js
@@ -6,6 +6,11 @@ const oauth2Client = new google.auth.OAuth2(
     process.env.GOOGLE_REDIRECT_URI
 );
 
-const SCOPES = ['https://www.googleapis.com/auth/calendar'];
+const SCOPES = [
+    'email',
+    'profile',
+    'https://www.googleapis.com/auth/calendar'
+
+];
 
 module.exports = { oauth2Client, SCOPES };

--- a/server/controller/authController.js
+++ b/server/controller/authController.js
@@ -17,11 +17,59 @@ exports.redirectToGoogleLogin = async (req, res) => {
 
 // Google redirects back here with a code
 exports.googleCallback = async (req, res) => {
-    const { code } = req.query;
-    const { tokens } = await oauth2Client.getToken(code);
-    req.session.tokens = tokens;
-    oauth2Client.setCredentials(tokens);
-    res.redirect('/studentIndex');
+    try {
+        const { code } = req.query;
+
+        // exchange code for tokens
+        /* The "tokens" consist of 3 different tokens:
+        * 1. access_token - makes API calls (Google Calendar) (1 hour lifspan)
+        * 2. refresh_token - gets a new access token when it expires (Long-lived lifespan)
+        * 3. id_token - proves who the user is (email/name/etc) (Single use lifespan)
+        */
+        const { tokens } = await oauth2Client.getToken(code);
+        // req.session.tokens = tokens;
+        oauth2Client.setCredentials(tokens);
+
+        // get user's email from the token
+        const ticket = await oauth2Client.verifyIdToken({
+            idToken: tokens.id_token,
+            audience: process.env.GOOGLE_CLIENT_ID,
+        });
+        
+        // Here, Google is sending back a JWT, and then getPayload()
+        // decodes the string into a plain JavaScript object with the user's
+        // info, that way we can grab the email.
+        const { email } = ticket.getPayload();
+
+        // checking to make sure this email belongs to our DB
+        const admin = await User.findOne({email, role:"admin"});
+
+        if (!admin) {
+            return res.render('login', 
+        {
+            error: "No admin found for that Google Account.",
+            title: 'Login Page',
+            cssStylesheet: 'login.css',
+            jsFile: null,
+            user: null
+        });
+        }
+
+        // setting our session
+        req.session.user = admin;
+        req.session.user.role = admin.role;
+
+        res.redirect('/adminIndex');
+
+    } catch (err) {
+        res.render("login", {
+            error: "Google login failed. Please try again.",
+            title: 'Login Page',
+            cssStylesheet: 'login.css',
+            jsFile: null,
+            user: null
+        });
+    }
 };
 
 // GET
@@ -90,14 +138,23 @@ exports.loginUser = async (req, res) => {
             });
         }
 
+        // checks to see if user is an admin
+        // if so, admins need to use Google OAuth to sign in.
+        if (user.role === "admin") {
+            return res.render('login', {
+                error: 'Admins must log in using Google.',
+                title: 'Login',
+                cssStylesheet: 'login.css',
+                jsFile: null,
+                user: null
+            });
+        }
+
         // stores user in session
         req.session.user = user;
 
         // checks user's role, redirects them to their corresponding index page
-        if (user.role === "admin") {
-            res.redirect('/adminIndex');
-        }
-        else if (user.role === "tutor") {
+        if (user.role === "tutor") {
             res.redirect('/tutorIndex');
         }
         else {

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -16,7 +16,8 @@
       <input type="text" id="email" name="email" required ><br><br>
       <label for="password">Password:</label>
       <input type="password" id="password" name="password" required ><br><br>
-      <button type="submit">Login</button>
+      <button type="submit">Login</button><br><br>
+      <a href="/auth/google">Admin? Login with Google</a>
     </form>
   </div>
 


### PR DESCRIPTION
 **Admins now use Google OAuth to login.**

> There's a hyperlink below the "Login" button on the login page that will direct the user to the Google OAuth page. At this moment in time, only Google accounts that I've put on the Google Auth Platform can login as an admin. (isututoradmin@gmail.com)
> If an admin tries to log in using the "regular" login page, the login will fail and tell the user to login using the Google OAuth.
> **Sessions** now have a time limit of 30 minutes, starting from the time of when the user makes their most recent request.