### PR TITLE
AL book appt controls

### DIFF
--- a/server/controller/appointmentController.js
+++ b/server/controller/appointmentController.js
@@ -50,6 +50,21 @@ exports.bookAppointment = async (req, res) => {
         bookedAppointments: [],
       });
     }
+    
+    //check if student already has an appointment at that time
+    const overlappingAppointment = await Appointment.findOne({
+      studentId: req.session.user._id,
+      appointmentDate: shift.shiftDate,
+      startTime: shift.startTime,
+      endTime: shift.endTime,
+      appointmentStatus: "scheduled"
+    });
+
+    if (overlappingAppointment) {
+      req.session.error = "You already have an appointment at that time.";
+      return res.redirect("/studentIndex");
+    }
+
 
     // create the appointment
     const appointment = new Appointment({

--- a/server/controller/appointmentController.js
+++ b/server/controller/appointmentController.js
@@ -50,7 +50,7 @@ exports.bookAppointment = async (req, res) => {
         bookedAppointments: [],
       });
     }
-    
+
     //check if student already has an appointment at that time
     const overlappingAppointment = await Appointment.findOne({
       studentId: req.session.user._id,
@@ -65,25 +65,33 @@ exports.bookAppointment = async (req, res) => {
       return res.redirect("/studentIndex");
     }
 
+    // book the appointment
+    // reserve the shift first to avoid race condition where two students try to book the same shift at the same time. 
+    const reservedShift = await TutorShift.findOneAndUpdate(
+      { _id: tutorShiftId, isBooked: false }, 
+      { isBooked: true }, 
+      { new: true } 
+    );
+    
+    if (!reservedShift) {
+      req.session.error = "That appointment is no longer available.";
+      return res.redirect("/studentIndex");
+    }
 
     // create the appointment
     const appointment = new Appointment({
       studentId: req.session.user._id,
-      tutorShiftId: shift._id,
+      tutorShiftId: reservedShift._id,
       course,
-      appointmentDate: shift.shiftDate,
-      startTime: shift.startTime,
-      endTime: shift.endTime,
+      appointmentDate: reservedShift.shiftDate,
+      startTime: reservedShift.startTime,
+      endTime: reservedShift.endTime,
       attendance: {
         attendanceStatus: "pending"
       }
     });
 
     await appointment.save();
-
-    // mark the shift as booked
-    shift.isBooked = true;
-    await shift.save();
 
     // send confirmation email to student and CC admin
     try {

--- a/server/controller/studentController.js
+++ b/server/controller/studentController.js
@@ -34,11 +34,14 @@ exports.getStudentIndex = async (req, res) => {
         // get all courses for the dropdown
         const courses = await Course.find().sort({ courseName: 1 });
 
+        const error = req.session.error || null;
+        delete req.session.error; // clear the error after displaying it once
+
         res.render("studentIndex", {
             title: "Book an Appointment",
             cssStylesheet: "studentStyle.css",
             jsFile: "studentScript.js",
-            error: null,
+            error,
             form: {},
             user: req.session.user,
             courses,


### PR DESCRIPTION
Students can no longer book two different appointments for the same time and day. I attempted to fix the race condition of two different students attempting to book the same appointment at the same time. I reserve the shift by marking it as booked with findOneAndUpdate() before creating the appointment. 

**Two other things that I found could help with the race condition is setting up a mongoose session but there were some issues with that that we can discuss later. The other thing we could do is add a unique constraint on tutorShiftId in the appointment schema. I did not do this yet because indexes are not created automatically so anyone who runs the "production" version the first time would need to run all the indexes manually so I figured we could discuss this later too. 