### PR TITLE
AL book and cancel appt email

### DIFF
--- a/server/controller/adminController.js
+++ b/server/controller/adminController.js
@@ -1,4 +1,6 @@
 const Appointment = require("../model/appointmentModel");
+const { sendEmail } = require("../services/emailService");
+const { adminCancellationTemplate } = require("../../views/templates/appointmentEmail");
 const User = require("../model/userModel");
 const Course = require("../model/courseModel");
 const TutorShift = require("../model/tutorShiftModel");
@@ -6,7 +8,6 @@ const CenterOpen = require("../model/centerOpenSchedule");
 const centerClosedSchedule = require("../model/centerClosedSchedule");
 const AuditLog = require("../model/auditLog");
 const bcrypt = require("bcrypt");
-const { trusted } = require("mongoose");
 const mongoose = require("mongoose");
 const { deleteCalendarEvent } = require("../services/calendarService");
 
@@ -152,8 +153,17 @@ exports.adminCancelAppointment = async (req, res) => {
     const appointmentId = req.body.appointmentId;
     const appointment = await Appointment.findById(
       appointmentId,
-      "appointmentStatus tutorShiftId calendarEventId",
-    ).populate("tutorShiftId");
+      "appointmentStatus tutorShiftId calendarEventId studentId appointmentDate startTime endTime course"
+    )
+    .populate("studentId", "fname lname email") 
+    .populate({
+      path: "tutorShiftId",
+      populate: {
+        path: "tutorId",
+        select: "fname lname",
+      },
+    });
+
 
     if (!appointment) {
       return res.render("adminIndex", {
@@ -228,26 +238,24 @@ exports.adminCancelAppointment = async (req, res) => {
     }
     // ────────────────────────────────────────────────────────────
 
-    //console.log("information for email", appointment.studentId.fname, appointment.tutorShiftId.tutorId.fname, appointment.tutorShiftId.tutorId.lname, appointment.appointmentDate, appointment.startTime, appointment.endTime, appointment.course);
-
     // send cancellation notification email to student and CC admin
-    // try {
-    //   await sendEmail({
-    //     to: req.session.user.email,
-    //     cc: process.env.GMAIL_ADMIN, // CC admin
-    //     subject: "Appointment Cancellation",
-    //     html: adminCancellationTemplate({
-    //       studentName: req.session.user.fname,
-    //       tutorName: shift.tutorId.fname + " " + shift.tutorId.lname,
-    //       date: shift.shiftDate.toLocaleDateString('en-US', { timeZone: 'UTC' }),
-    //       time: `${shift.startTime} - ${shift.endTime}`,
-    //       course
-    //     })
-    //   });
+    try {
+      await sendEmail({
+        to: appointment.studentId.email,
+        cc: process.env.GMAIL_ADMIN, // CC admin
+        subject: "Appointment Cancellation",
+        html: adminCancellationTemplate({
+          studentName: appointment.studentId.fname,
+          tutorName: `${appointment.tutorShiftId.tutorId.fname} ${appointment.tutorShiftId.tutorId.lname}`,
+          date: appointment.appointmentDate.toLocaleDateString('en-US', { timeZone: 'UTC' }),
+          time: `${appointment.startTime} - ${appointment.endTime}`,
+          course: appointment.course
+        })
+      });
 
-    // } catch (emailErr) {
-    //   console.error("Email sending error");
-    // }
+    } catch (emailErr) {
+      console.error("Admin cancellation email sending error.");
+    }
 
     return res.redirect("/adminIndex");
   } catch (err) {

--- a/server/controller/appointmentController.js
+++ b/server/controller/appointmentController.js
@@ -1,8 +1,5 @@
 const { sendEmail } = require("../services/emailService");
-const {
-  confirmationTemplate,
-  cancellationTemplate,
-} = require("../../views/templates/appointmentEmail");
+const { confirmationTemplate } = require("../../views/templates/appointmentEmail");
 const Appointment = require("../model/appointmentModel");
 const TutorShift = require("../model/tutorShiftModel");
 const mongoose = require("mongoose");
@@ -136,24 +133,16 @@ exports.bookAppointment = async (req, res) => {
         subject: "Appointment Confirmation",
         html: confirmationTemplate({
           studentName: req.session.user.fname,
-          tutorName: shift.tutorId.fname + " " + shift.tutorId.lname,
-          date: shift.shiftDate.toLocaleDateString("en-US", {
+          tutorName: `${shift.tutorId.fname} ${shift.tutorId.lname}`,
+          date: appointment.appointmentDate.toLocaleDateString("en-US", {
             timeZone: "UTC",
           }),
-          time: `${shift.startTime} - ${shift.endTime}`,
-          course,
+          time: `${appointment.startTime} - ${appointment.endTime}`,
+          course: appointment.course,
         }),
       });
     } catch (emailErr) {
-      res.render("studentAppointment", {
-        title: "Book an Appointment",
-        cssStylesheet: "studentStyle.css",
-        jsFile: "studentScript.js",
-        error: "Email sending error.",
-        user: req.session.user,
-        availableShifts: [],
-        bookedAppointments: [],
-      });
+      console.error("Student book appointment email sending error.");
     }
 
     res.redirect("/studentIndex");

--- a/server/controller/studentController.js
+++ b/server/controller/studentController.js
@@ -3,6 +3,8 @@ const TutorShift = require("../model/tutorShiftModel");
 const Course = require("../model/courseModel");
 const mongoose = require("mongoose");
 const Appointment = require("../model/appointmentModel");
+const { sendEmail } = require("../services/emailService");
+const { studentCancellationTemplate } = require("../../views/templates/appointmentEmail");
 const { deleteCalendarEvent } = require('../services/calendarService');
 
 // GET: load the student index page with selection for course and day to view available appointments
@@ -226,6 +228,12 @@ exports.cancelAppointment = async (req, res) => {
         const appointment = await Appointment.findOne({
             _id: appointmentId, 
             studentId: req.session.user._id
+        }).populate({
+            path: 'tutorShiftId',
+            populate: {
+                path: 'tutorId',
+                select: 'fname lname'
+            } 
         });
            
 
@@ -246,7 +254,7 @@ exports.cancelAppointment = async (req, res) => {
 
          // change tutorshift to open (isBooked: false) 
         if(appointment.tutorShiftId){
-            await TutorShift.findByIdAndUpdate(appointment.tutorShiftId._id, {
+            await TutorShift.findByIdAndUpdate(appointment.tutorShiftId, {
                 isBooked: false
             });
         }
@@ -278,49 +286,40 @@ exports.cancelAppointment = async (req, res) => {
         }
         // ────────────────────────────────────────────────────────────
 
-        //console.log("student cancel email information", appointment.appointmentDate, appointment.startTime, appointment.endTime, appointment.course, appointment.tutorShiftId.tutorId.fname, appointment.tutorShiftId.tutorId.lname);
-
-        // // send cancellation confirmation email to student and CC admin
-        // try {
-        //     await sendEmail({
-        //     to: req.session.user.email,
-        //     cc: process.env.GMAIL_ADMIN, // CC admin
-        //     subject: "Appointment Cancellation",
-        //     html: studentCancellationTemplate({
-        //         studentName: req.session.user.fname,
-        //         tutorName: shift.tutorId.fname + " " + shift.tutorId.lname,
-        //         date: shift.shiftDate.toLocaleDateString('en-US', { timeZone: 'UTC' }),
-        //         time: `${shift.startTime} - ${shift.endTime}`,
-        //         course
-        //         })
-        //     });
+        // send cancellation confirmation email to student and CC admin
+        try {
+            await sendEmail({
+            to: req.session.user.email,
+            cc: process.env.GMAIL_ADMIN, // CC admin
+            subject: "Appointment Cancellation",
+            html: studentCancellationTemplate({
+                studentName: req.session.user.fname,
+                tutorName: `${appointment.tutorShiftId.tutorId.fname} ${appointment.tutorShiftId.tutorId.lname}`,
+                date: appointment.appointmentDate.toLocaleDateString('en-US', { timeZone: 'UTC' }),
+                time: `${appointment.startTime} - ${appointment.endTime}`,
+                course: appointment.course
+                })
+            });
         
-        // } catch (emailErr) {
-        //     console.error("Email sending error");
-        // }
-
-
+        } catch (emailErr) {
+            console.error("Student cancellation email sending error.");
+        }
+        
          // reload page 
          res.redirect('/studentAppointment');
-
-
     } // end of try 
     catch(err){
         //console.error("Error cancelling appointment:", err);
         const bookedAppointments = await Appointment.find({
             studentId: req.session.user._id
         });
-
-        
-            res.render("studentAppointment", {
-                title: "Booked Appointments",
-                cssStylesheet: "studentStyle.css",
-                jsFile: "studentScript.js",
-                error: "Could not cancel appointment.",
-                user: req.session.user,
-                bookedAppointments
-
-            });
-
+        res.render("studentAppointment", {
+            title: "Booked Appointments",
+            cssStylesheet: "studentStyle.css",
+            jsFile: "studentScript.js",
+            error: "Could not cancel appointment.",
+            user: req.session.user,
+            bookedAppointments
+        });
     }
 }

--- a/views/templates/appointmentEmail.js
+++ b/views/templates/appointmentEmail.js
@@ -12,7 +12,7 @@ function confirmationTemplate({ studentName, tutorName, date, time, course }) {
   `;
 }
 
-function cancellationTemplate({ studentName, tutorName, date, time, course }) {
+function studentCancellationTemplate({ studentName, tutorName, date, time, course }) {
   return `
     <p>Hi ${studentName},</p>
     <p>Your tutoring appointment with ${tutorName} has been cancelled.</p>
@@ -27,35 +27,19 @@ function cancellationTemplate({ studentName, tutorName, date, time, course }) {
   `;
 }
 
-// function studentCancellationTemplate({ studentName, tutorName, date, time, course }) {
-//   return `
-//     <p>Hi ${studentName},</p>
-//     <p>Your tutoring appointment with ${tutorName} has been cancelled.</p>
+function adminCancellationTemplate({ studentName, tutorName, date, time, course }) {
+  return `
+    <p>Hi ${studentName},</p>
+    <p>An administrator has cancelled your tutoring appointment with ${tutorName}.</p>
 
-//     <p>Appointment details:</p>
-//     <p>
-//         <b>Course:</b> ${course}<br/>
-//         <b>Date:</b> ${date}<br/>
-//         <b>Time:</b> ${time}
-//     </p>
+    <p>Appointment details:</p>
+    <p>
+        <b>Course:</b> ${course}<br/>
+        <b>Date:</b> ${date}<br/>
+        <b>Time:</b> ${time}
+    </p>
 
-//   `;
-// }
+  `;
+}
 
-// function adminCancellationTemplate({ studentName, tutorName, date, time, course }) {
-//   return `
-//     <p>Hi ${studentName},</p>
-//     <p>An administrator has cancelled your tutoring appointment with ${tutorName}.</p>
-
-//     <p>Appointment details:</p>
-//     <p>
-//         <b>Course:</b> ${course}<br/>
-//         <b>Date:</b> ${date}<br/>
-//         <b>Time:</b> ${time}
-//     </p>
-
-//   `;
-// }
-
-//module.exports = { confirmationTemplate, studentCancellationTemplate, adminCancellationTemplate };
-module.exports = { confirmationTemplate, cancellationTemplate };
+module.exports = { confirmationTemplate, studentCancellationTemplate, adminCancellationTemplate };


### PR DESCRIPTION
The email for book appointment, student cancel appointment, and admin cancel appointment is now all linked up. The email content is now based on the appointment information instead of tutor shift information. 
I created a new email template for admin cancel appointment so when an admin cancels an appointment, the student knows that an admin is the one who did it. 
For the errors for the email I decided that the appointment will still be booked or canceled even if the email never sent so the user will current not see that an email error occurred. I can change this later to notify the user but to me at least, if just the email breaks, I don't think that should stop the user from booking or canceling an appointment. We can discuss how to handle this situation at a later meeting though. 