### PR TITLE
tutor view cancelled appts

### DIFF
--- a/assets/css/tutorStyle.css
+++ b/assets/css/tutorStyle.css
@@ -70,4 +70,5 @@ textarea::placeholder {
     display: inline-block;
     margin-right: 15px;
     margin-bottom: 10px;
+    text-align: center;
 }

--- a/assets/js/tutorScript.js
+++ b/assets/js/tutorScript.js
@@ -112,6 +112,8 @@ showButton.addEventListener("click", ()=> {
             selectShow.value = "show";
         } else if (showValue === "noShow") {
             selectShow.value = "no-show";
+        } else if (showValue === "pending") {
+            selectShow.value = "pending";
         } else {
             selectShow.value = "";
         }

--- a/server/controller/tutorController.js
+++ b/server/controller/tutorController.js
@@ -1,200 +1,268 @@
-const TutorShift = require('../model/tutorShiftModel');
+const TutorShift = require("../model/tutorShiftModel");
 const Appointment = require("../model/appointmentModel");
 const centerOpen = require("../model/centerOpenSchedule");
-const mongoose = require('mongoose');
+const mongoose = require("mongoose");
 
 // GET: renders tutor index
 exports.getTutorIndex = async (req, res) => {
-    try {
-        // if not an auth user, send to login page
-        if (!req.session.user) {
-            return res.render('login', {
-                title: 'Login Page',
-                cssStylesheet: 'login.css',
-                jsFile: 'login.js',
-                error: "User not logged in.",
-                user: null
-            });
-        }
-
-        // if auth user but not a tutor, send to login page
-        if (req.session.user.role !== "tutor") {
-            return res.render('login', {
-                title: 'Login Page',
-                cssStylesheet: 'login.css',
-                jsFile: 'login.js',
-                error: "Access denied. Only tutors can view this page.",
-                user: req.session.user
-            });
-        }
-
-        const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
-        // function to get all shifts for the tutor and sort by date and time
-        let upcomingTutorShifts = [];
-        let shiftError = null;
-        try {
-            upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
-        } catch (err) {
-            shiftError = "Failed to load upcoming tutor shifts.";
-        }
-
-
-        // render tutor page
-        res.render('tutorIndex', {
-            error: null,
-            shiftError,
-            title: 'Tutor Appointments',
-            cssStylesheet: 'tutorStyle.css',
-            jsFile: 'tutorScript.js',
-            user: req.session.user,
-            bookedAppointments: [],
-            appointmentsLoaded: false,
-            upcomingTutorShifts,
-            pastBookedAppointments: [],
-            pastAppointmentsLoaded: false
-        });
-
-    } catch (err) {
-        res.render('tutorIndex', {
-            error: "Failed to load tutor index page.",
-            shiftError: null,
-            title: 'Tutor Appointments',
-            cssStylesheet: 'tutorStyle.css',
-            jsFile: 'tutorScript.js',
-            user: req.session.user,
-            bookedAppointments: [],
-            appointmentsLoaded: false,
-            upcomingTutorShifts: [],
-            pastBookedAppointments: [],
-            pastAppointmentsLoaded: false
-        });
+  try {
+    // if not an auth user, send to login page
+    if (!req.session.user) {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "User not logged in.",
+        user: null,
+      });
     }
 
-};
+    // if auth user but not a tutor, send to login page
+    if (req.session.user.role !== "tutor") {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "Access denied. Only tutors can view this page.",
+        user: req.session.user,
+      });
+    }
 
+    const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
+    // function to get all shifts for the tutor and sort by date and time
+    let upcomingTutorShifts = [];
+    let shiftError = null;
+    try {
+      upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
+    } catch (err) {
+      shiftError = "Failed to load upcoming tutor shifts.";
+    }
+
+    // render tutor page
+    res.render("tutorIndex", {
+      error: null,
+      shiftError,
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: false,
+      upcomingTutorShifts,
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: false,
+    });
+  } catch (err) {
+    res.render("tutorIndex", {
+      error: "Failed to load tutor index page.",
+      shiftError: null,
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: false,
+      upcomingTutorShifts: [],
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: false,
+    });
+  }
+};
 
 // GET: display the tutor's booked appointments
 exports.getTutorAppointments = async (req, res) => {
-    try {
-        // if not an auth user, send to login page
-        if (!req.session.user) {
-            return res.render('login',
-                {
-                    title: 'Login Page',
-                    cssStylesheet: 'login.css',
-                    jsFile: 'login.js',
-                    error: "User not logged in.",
-                    user: null
-                });
-        }
-
-        // if auth user but not a tutor, send to login page
-        if (req.session.user.role !== "tutor") {
-            return res.render('login',
-                {
-                    title: 'Login Page',
-                    cssStylesheet: 'login.css',
-                    jsFile: 'login.js',
-                    error: "Access denied. Only tutors can view this page.",
-                    user: null
-                });
-        }
-
-        // get current session user id and convert to ObjectId format for finding booked appointments and shifts
-        const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
-
-        // function to get all shifts for the tutor and sort by date and time
-        let upcomingTutorShifts = [];
-        let shiftError = null;
-        try {
-            upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
-        } catch (err) {
-            shiftError = "Failed to load tutor shifts.";
-        }
-
-        // get any booked appointments under current tutor user
-        const bookedAppointments = await Appointment.aggregate([
-            { $lookup: { from: "tutorshifts", localField: "tutorShiftId", foreignField: "_id", as: "tutorShift" } },
-            { $unwind: "$tutorShift" },
-            { $match: { "tutorShift.tutorId": tutorId, "tutorShift.isBooked": true, appointmentDate: { $gte: new Date(new Date().setUTCHours(0, 0, 0, 0)) } } }, // shows appointments for today and future (not based on time)
-            { $project: { course: 1, appointmentDate: 1, startTime: 1, endTime: 1, appointmentStatus: 1, tutorComments: 1, attendance: 1 } },
-            { $sort: { appointmentDate: 1, startTime: 1 } }
-        ]);
-
-        // get any past booked appointments under current tutor user
-        let pastBookedAppointments = await Appointment.aggregate([
-            { $lookup: { from: "tutorshifts", localField: "tutorShiftId", foreignField: "_id", as: "tutorShift" } },
-            { $unwind: "$tutorShift" },
-            { $match: { "tutorShift.tutorId": tutorId, "tutorShift.isBooked": true, appointmentDate: { $lt: new Date(new Date().setUTCHours(0, 0, 0, 0)) } } }, // shows appointments for today and past (not based on time)
-            { $project: { course: 1, appointmentDate: 1, startTime: 1, endTime: 1, appointmentStatus: 1, tutorComments: 1, attendance: 1 } },
-            { $sort: { appointmentDate: 1, startTime: 1 } }
-        ]);
-
-        // update appointment status to completed if past the current date and time (past appointments only checks date)
-        for (let i = 0; i < pastBookedAppointments.length; i++) {
-            const currAppointment = pastBookedAppointments[i];
-            const currAppointmentDate = new Date(currAppointment.appointmentDate);
-            // set the hours for the date of the current appointment to the end time using the stored hours
-            currAppointmentDate.setHours(
-                parseInt(currAppointment.endTime.split(":")[0]),
-                parseInt(currAppointment.endTime.split(":")[1])
-            );
-
-            // update status to completed if current appointment is set to scheduled and past the current time
-            if (currAppointment.appointmentStatus === "scheduled" && currAppointmentDate < new Date()) {
-                await Appointment.findByIdAndUpdate(currAppointment._id, { appointmentStatus: "completed" });
-                pastBookedAppointments[i].appointmentStatus = "completed";
-            }
-        }
-
-        // render tutorIndex page with bookedAppointments and pastBookedAppointments under tutor
-        res.render("tutorIndex", {
-            title: "Tutor Appointments",
-            cssStylesheet: "tutorStyle.css",
-            jsFile: "tutorScript.js",
-            error: null,
-            shiftError,
-            user: req.session.user,
-            bookedAppointments,
-            appointmentsLoaded: true,
-            upcomingTutorShifts,
-            pastBookedAppointments,
-            pastAppointmentsLoaded: true
-        });
-    } catch (err) {
-        res.render("tutorIndex", {
-            title: "Tutor Appointments",
-            cssStylesheet: "tutorStyle.css",
-            jsFile: "tutorScript.js",
-            error: "Failed to show appointments.",
-            shiftError: null,
-            user: req.session.user,
-            bookedAppointments: [],
-            appointmentsLoaded: true,
-            upcomingTutorShifts: [],
-            pastBookedAppointments: [],
-            pastAppointmentsLoaded: true
-        });
+  try {
+    // if not an auth user, send to login page
+    if (!req.session.user) {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "User not logged in.",
+        user: null,
+      });
     }
-}
+
+    // if auth user but not a tutor, send to login page
+    if (req.session.user.role !== "tutor") {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "Access denied. Only tutors can view this page.",
+        user: null,
+      });
+    }
+
+    // get current session user id and convert to ObjectId format for finding booked appointments and shifts
+    const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
+
+    // function to get all shifts for the tutor and sort by date and time
+    let upcomingTutorShifts = [];
+    let shiftError = null;
+    try {
+      upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
+    } catch (err) {
+      shiftError = "Failed to load tutor shifts.";
+    }
+
+    // get any booked appointments under current tutor user
+    const bookedAppointments = await Appointment.aggregate([
+      {
+        $lookup: {
+          from: "tutorshifts",
+          localField: "tutorShiftId",
+          foreignField: "_id",
+          as: "tutorShift",
+        },
+      },
+      { $unwind: "$tutorShift" },
+      {
+        $lookup: {
+          from: "users",
+          localField: "studentId",
+          foreignField: "_id",
+          as: "student",
+        },
+      },
+      { $unwind: "$student" },
+      {
+        $match: {
+          "tutorShift.tutorId": tutorId,
+          "tutorShift.isBooked": true,
+          appointmentDate: {
+            $gte: new Date(new Date().setUTCHours(0, 0, 0, 0)),
+          },
+        },
+      }, // shows appointments for today and future (not based on time)
+      {
+        $project: {
+          course: 1,
+          appointmentDate: 1,
+          startTime: 1,
+          endTime: 1,
+          tutorComments: 1,
+          attendance: 1,
+          "student.fname": 1,
+          "student.lname": 1,
+        },
+      },
+      { $sort: { appointmentDate: 1, startTime: 1 } },
+    ]);
+
+    // get any past booked appointments under current tutor user
+    let pastBookedAppointments = await Appointment.aggregate([
+      {
+        $lookup: {
+          from: "tutorshifts",
+          localField: "tutorShiftId",
+          foreignField: "_id",
+          as: "tutorShift",
+        },
+      },
+      { $unwind: "$tutorShift" },
+      {
+        $lookup: {
+          from: "users",
+          localField: "studentId",
+          foreignField: "_id",
+          as: "student",
+        },
+      },
+      { $unwind: "$student" },
+      {
+        $match: {
+          "tutorShift.tutorId": tutorId,
+          "tutorShift.isBooked": true,
+          appointmentDate: {
+            $lt: new Date(new Date().setUTCHours(0, 0, 0, 0)),
+          },
+        },
+      }, // shows appointments for today and past (not based on time)
+      {
+        $project: {
+          course: 1,
+          appointmentDate: 1,
+          startTime: 1,
+          endTime: 1,
+          tutorComments: 1,
+          attendance: 1,
+          "student.fname": 1,
+          "student.lname": 1,
+        },
+      },
+      { $sort: { appointmentDate: 1, startTime: 1 } },
+    ]);
+
+    // update appointment status to completed if past the current date and time (past appointments only checks date)
+    for (let i = 0; i < pastBookedAppointments.length; i++) {
+      const currAppointment = pastBookedAppointments[i];
+      const currAppointmentDate = new Date(currAppointment.appointmentDate);
+      // set the hours for the date of the current appointment to the end time using the stored hours
+      currAppointmentDate.setHours(
+        parseInt(currAppointment.endTime.split(":")[0]),
+        parseInt(currAppointment.endTime.split(":")[1]),
+      );
+
+      // update status to completed if current appointment is set to scheduled and past the current time
+      if (
+        currAppointment.appointmentStatus === "scheduled" &&
+        currAppointmentDate < new Date()
+      ) {
+        await Appointment.findByIdAndUpdate(currAppointment._id, {
+          appointmentStatus: "completed",
+        });
+        pastBookedAppointments[i].appointmentStatus = "completed";
+      }
+    }
+
+    // render tutorIndex page with bookedAppointments and pastBookedAppointments under tutor
+    res.render("tutorIndex", {
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      error: null,
+      shiftError,
+      user: req.session.user,
+      bookedAppointments,
+      appointmentsLoaded: true,
+      upcomingTutorShifts,
+      pastBookedAppointments,
+      pastAppointmentsLoaded: true,
+    });
+  } catch (err) {
+    res.render("tutorIndex", {
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      error: "Failed to show appointments.",
+      shiftError: null,
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: true,
+      upcomingTutorShifts: [],
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: true,
+    });
+  }
+};
 
 // try to get the tutor's upcoming shifts, if error occurs render page with error message and empty shifts array
 async function getUpcomingTutorShifts(theTutorId) {
   try {
     const shifts = await TutorShift.find({
       tutorId: theTutorId,
-      shiftDate: { $gte: new Date(new Date().setUTCHours(0, 0, 0, 0)) }
+      shiftDate: { $gte: new Date(new Date().setUTCHours(0, 0, 0, 0)) },
     })
-    .sort({ shiftDate: 1, startTime: 1 })
-    .lean(); // transform mongoose documents to plain JS objects for easier manipulation
+      .sort({ shiftDate: 1, startTime: 1 })
+      .lean(); // transform mongoose documents to plain JS objects for easier manipulation
 
     // if there are no shifts found for the tutor, return an empty array
     if (!shifts || shifts.length === 0) {
-        return [];
+      return [];
     }
 
     return groupNonconsecutiveShifts(shifts);
-
   } catch (err) {
     throw err;
   }
@@ -212,14 +280,14 @@ function groupNonconsecutiveShifts(shifts) {
       map.set(dateKey, {
         tutorId: shift.tutorId,
         shiftDate: shift.shiftDate,
-        timeRanges: []
+        timeRanges: [],
       });
     }
 
     const group = map.get(dateKey);
     const lastRange = group.timeRanges[group.timeRanges.length - 1];
 
-    // if lastRange exists and if the end time of the last range matches the start time of the current shift, 
+    // if lastRange exists and if the end time of the last range matches the start time of the current shift,
     // it is consecutive and extend the last group end time to the current shift end time
     // otherwise, add a new time range to the group for the current shift
     if (lastRange && lastRange.shiftEnd === shift.startTime) {
@@ -227,7 +295,7 @@ function groupNonconsecutiveShifts(shifts) {
     } else {
       group.timeRanges.push({
         shiftStart: shift.startTime,
-        shiftEnd: shift.endTime
+        shiftEnd: shift.endTime,
       });
     }
   }
@@ -235,521 +303,622 @@ function groupNonconsecutiveShifts(shifts) {
   return Array.from(map.values());
 }
 
-
 // POST: update submitted comment in MongoDB for specific tutor appointment selected
 exports.submitComment = async (req, res) => {
+  try {
+    // if not an auth user, send to login page
+    if (!req.session.user) {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "User not logged in.",
+        user: null,
+      });
+    }
+
+    // if auth user but not a tutor, send to login page
+    if (req.session.user.role !== "tutor") {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "Access denied. Only tutors can view this page.",
+        user: null,
+      });
+    }
+
+    const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
+    // function to get all shifts for the tutor and sort by date and time
+    let upcomingTutorShifts = [];
+    let shiftError = null;
     try {
-        // if not an auth user, send to login page
-        if (!req.session.user) {
-            return res.render('login',
-            {
-                title: 'Login Page',
-                cssStylesheet: 'login.css',
-                jsFile: 'login.js',
-                error: "User not logged in.",
-                user: null
-            });
-        }
-
-        // if auth user but not a tutor, send to login page
-        if (req.session.user.role !== "tutor") {
-            return res.render('login',
-            {
-                title: 'Login Page',
-                cssStylesheet: 'login.css',
-                jsFile: 'login.js',
-                error: "Access denied. Only tutors can view this page.",
-                user: null
-            });
-        }
-
-        const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
-        // function to get all shifts for the tutor and sort by date and time
-        let upcomingTutorShifts = [];
-        let shiftError = null;
-        try {
-            upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
-        } catch (err) {
-            shiftError = "Failed to load upcoming tutor shifts.";
-        }
-
-        // get appointment id and comments
-        const appointmentId = req.body.selectedAppointment;
-        const comments = req.body['comments-textarea'];
-
-        // if comments not entered
-        if (!comments && comments !== "") {
-            return res.render('tutorIndex', {
-                error: "Comment required",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // no appointment selected
-        if (!appointmentId) {
-            return res.render('tutorIndex', {
-                error: "No appointment selected.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // update the comments for specific appointment
-        const appointmentExist = await Appointment.findOneAndUpdate({ _id: appointmentId }, { $set: { tutorComments: comments } });
-
-        // no appointment found
-        if (!appointmentExist) {
-            return res.render('tutorIndex', {
-                error: "Appointment not found.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // re-render tutor page
-        res.render('tutorIndex', {
-            error: null,
-            shiftError,
-            title: 'Tutor Appointments',
-            cssStylesheet: 'tutorStyle.css',
-            jsFile: 'tutorScript.js',
-            user: req.session.user,
-            bookedAppointments: [],
-            appointmentsLoaded: false,
-            upcomingTutorShifts,
-            pastBookedAppointments: [],
-            pastAppointmentsLoaded: false
-        });
+      upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
     } catch (err) {
-        res.render('tutorIndex', {
-            error: "Failed to load tutor index page.",
-            shiftError: null,
-            title: 'Tutor Appointments',
-            cssStylesheet: 'tutorStyle.css',
-            jsFile: 'tutorScript.js',
-            user: req.session.user,
-            bookedAppointments: [],
-            appointmentsLoaded: false,
-            upcomingTutorShifts: [],
-            pastBookedAppointments: [],
-            pastAppointmentsLoaded: false
-        });
-    }   
-}
+      shiftError = "Failed to load upcoming tutor shifts.";
+    }
 
+    // get appointment id and comments
+    const appointmentId = req.body.selectedAppointment;
+    const comments = req.body["comments-textarea"];
 
-// GET: display specific tutor comments in comments text area if any for appointment selected
-// exports.viewComment = async (req, res) => {
+    // if comments not entered
+    if (!comments && comments !== "") {
+      return res.render("tutorIndex", {
+        error: "Comment required",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
 
-// }
+    // no appointment selected
+    if (!appointmentId) {
+      return res.render("tutorIndex", {
+        error: "No appointment selected.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
 
+    // update the comments for specific appointment
+    const appointmentExist = await Appointment.findOneAndUpdate(
+      { _id: appointmentId },
+      { $set: { tutorComments: comments } },
+    );
+
+    // no appointment found
+    if (!appointmentExist) {
+      return res.render("tutorIndex", {
+        error: "Appointment not found.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // re-render tutor page
+    res.render("tutorIndex", {
+      error: null,
+      shiftError,
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: false,
+      upcomingTutorShifts,
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: false,
+    });
+  } catch (err) {
+    res.render("tutorIndex", {
+      error: "Failed to load tutor index page.",
+      shiftError: null,
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: false,
+      upcomingTutorShifts: [],
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: false,
+    });
+  }
+};
 
 // POST: update submitted start and end times in MongoDB for specific tutor appointment selected
 exports.submitTimes = async (req, res) => {
-    try {
-        // if not an auth user, send to login page
-        if (!req.session.user) {
-            return res.render('login',
-            {
-                title: 'Login Page',
-                cssStylesheet: 'login.css',
-                jsFile: 'login.js',
-                error: "User not logged in.",
-                user: null
-            });
-        }
-
-        // if auth user but not a tutor, send to login page
-        if (req.session.user.role !== "tutor") {
-            return res.render('login',
-            {
-                title: 'Login Page',
-                cssStylesheet: 'login.css',
-                jsFile: 'login.js',
-                error: "Access denied. Only tutors can view this page.",
-                user: null
-            });
-        }
-
-        const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
-        // function to get all shifts for the tutor and sort by date and time
-        let upcomingTutorShifts = [];
-        let shiftError = null;
-        try {
-            upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
-        } catch (err) {
-            shiftError = "Failed to load upcoming tutor shifts.";
-        }
-
-
-        // get appointment id and start and end times
-        // Note: actual start and end times do not need to end in :00
-        const appointmentId = req.body.selectedAppointment;
-        const sessionStartTime = req.body['session-start-time'];
-        const sessionEndTime = req.body['session-end-time'];
-
-        // if start and end times not entered
-        if (!sessionStartTime || !sessionEndTime) {
-            return res.render('tutorIndex', {
-                error: "Start time and end time are required.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // no appointment selected
-        if (!appointmentId) {
-            return res.render('tutorIndex', {
-                error: "No appointment selected.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // split entered times
-        const startHour = Number(sessionStartTime.split(":")[0]); // Get start hour as an integer
-        const endHour = Number(sessionEndTime.split(":")[0]); // Get end hour as an integer
-        const startMinute = Number(sessionStartTime.split(":")[1]); // Get start minute as an integer
-        const endMinute = Number(sessionEndTime.split(":")[1]); // Get end minute as an integer
-
-
-        // get appointment in order to get date
-        const appointment = await Appointment.findOne({ _id: appointmentId }).populate("appointmentDate");
-
-        // no appointment found
-        if (!appointment) {
-            return res.render('tutorIndex', {
-                error: "Appointment not found.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // compare entered times with general center hours
-        const weekdays = await centerOpen.find(); // get the days of the week
-        const weekdayIndex = appointment.appointmentDate.getDay(); // get weekday index (0 = Sunday, 6 = Saturday)
-        const weekdayIndices = [6, 0, 1, 2, 3, 4, 5]; // since getDay indexes 0 = Sunday, 6 = Saturday, move the indices around to match the weekdays in application
-        const weekday = weekdays[weekdayIndices[weekdayIndex]]; // get the weekday object
-        const centerStartHour = Number(weekday.openTime.split(":")[0]); // Get start hour as an integer
-        const centerEndHour = Number(weekday.closeTime.split(":")[0]); // Get end hour as an integer
-        const centerEndMinute = Number(weekday.closeTime.split(":")[1]); // Get end minute as an integer
-
-        // start time cannot precede general center open time and end time cannot exceed the general center close time
-        if (startHour < centerStartHour || endHour > centerEndHour || (endHour === centerEndHour && endMinute > centerEndMinute)) {
-            return res.render('tutorIndex', {
-                error: "Start time and end time cannot occur outside general center hours.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-
-        // start time cannot be greater than end time
-        if (startHour > endHour || ((endHour - startHour === 0) && endMinute < startMinute)) {
-            return res.render('tutorIndex', {
-                error: "Start time must precede end time.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-
-        // session can only be 5 minutes short
-        if (((endHour - startHour === 1) && (60 - startMinute) + endMinute < 5) || ((startHour === endHour) && (endMinute - startMinute < 5))) {
-            return res.render('tutorIndex', {
-                error: "Appointment must be at least 5 minutes long.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // session can only be an hour max long
-        if (endHour - startHour > 1 || ((endHour - startHour === 1) && (endMinute > startMinute))) {
-            return res.render('tutorIndex', {
-                error: "Appointment can only be an hour long maximum.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // update the times for specific appointment
-        const appointmentUpdated = await Appointment.findOneAndUpdate({ _id: appointmentId }, { $set: { "attendance.actualStart": sessionStartTime, "attendance.actualEnd": sessionEndTime } });
-
-        // appointment unable to update
-        if (!appointmentUpdated) {
-            return res.render('tutorIndex', {
-                error: "Appointment could not be updated.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // re-render tutor page
-        res.render('tutorIndex', {
-            error: null,
-            shiftError,
-            title: 'Tutor Appointments',
-            cssStylesheet: 'tutorStyle.css',
-            jsFile: 'tutorScript.js',
-            user: req.session.user,
-            bookedAppointments: [],
-            appointmentsLoaded: false,
-            upcomingTutorShifts,
-            pastBookedAppointments: [],
-            pastAppointmentsLoaded: false
-        });
-    } catch (err) {
-        res.render('tutorIndex', {
-            error: "Failed to load tutor index page.",
-            shiftError: null,
-            title: 'Tutor Appointments',
-            cssStylesheet: 'tutorStyle.css',
-            jsFile: 'tutorScript.js',
-            user: req.session.user,
-            bookedAppointments: [],
-            appointmentsLoaded: false,
-            upcomingTutorShifts: [],
-            pastBookedAppointments: [],
-            pastAppointmentsLoaded: false
-        });
+  try {
+    // if not an auth user, send to login page
+    if (!req.session.user) {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "User not logged in.",
+        user: null,
+      });
     }
-}
 
+    // if auth user but not a tutor, send to login page
+    if (req.session.user.role !== "tutor") {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "Access denied. Only tutors can view this page.",
+        user: null,
+      });
+    }
+
+    const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
+    // function to get all shifts for the tutor and sort by date and time
+    let upcomingTutorShifts = [];
+    let shiftError = null;
+    try {
+      upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
+    } catch (err) {
+      shiftError = "Failed to load upcoming tutor shifts.";
+    }
+
+    // get appointment id and start and end times
+    // Note: actual start and end times do not need to end in :00
+    const appointmentId = req.body.selectedAppointment;
+    const sessionStartTime = req.body["session-start-time"];
+    const sessionEndTime = req.body["session-end-time"];
+
+    // if start and end times not entered
+    if (!sessionStartTime || !sessionEndTime) {
+      return res.render("tutorIndex", {
+        error: "Start time and end time are required.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // no appointment selected
+    if (!appointmentId) {
+      return res.render("tutorIndex", {
+        error: "No appointment selected.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // split entered times
+    const startHour = Number(sessionStartTime.split(":")[0]); // Get start hour as an integer
+    const endHour = Number(sessionEndTime.split(":")[0]); // Get end hour as an integer
+    const startMinute = Number(sessionStartTime.split(":")[1]); // Get start minute as an integer
+    const endMinute = Number(sessionEndTime.split(":")[1]); // Get end minute as an integer
+
+    // get appointment in order to get date
+    const appointment = await Appointment.findOne({
+      _id: appointmentId,
+    }).populate("appointmentDate");
+
+    // no appointment found
+    if (!appointment) {
+      return res.render("tutorIndex", {
+        error: "Appointment not found.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // compare entered times with general center hours
+    const weekdays = await centerOpen.find(); // get the days of the week
+    const weekdayIndex = appointment.appointmentDate.getDay(); // get weekday index (0 = Sunday, 6 = Saturday)
+    const weekdayIndices = [6, 0, 1, 2, 3, 4, 5]; // since getDay indexes 0 = Sunday, 6 = Saturday, move the indices around to match the weekdays in application
+    const weekday = weekdays[weekdayIndices[weekdayIndex]]; // get the weekday object
+    const centerStartHour = Number(weekday.openTime.split(":")[0]); // Get start hour as an integer
+    const centerEndHour = Number(weekday.closeTime.split(":")[0]); // Get end hour as an integer
+    const centerEndMinute = Number(weekday.closeTime.split(":")[1]); // Get end minute as an integer
+
+    // start time cannot precede general center open time and end time cannot exceed the general center close time
+    if (
+      startHour < centerStartHour ||
+      endHour > centerEndHour ||
+      (endHour === centerEndHour && endMinute > centerEndMinute)
+    ) {
+      return res.render("tutorIndex", {
+        error:
+          "Start time and end time cannot occur outside general center hours.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // start time cannot be greater than end time
+    if (
+      startHour > endHour ||
+      (endHour - startHour === 0 && endMinute < startMinute)
+    ) {
+      return res.render("tutorIndex", {
+        error: "Start time must precede end time.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // session can only be 5 minutes short
+    if (
+      (endHour - startHour === 1 && 60 - startMinute + endMinute < 5) ||
+      (startHour === endHour && endMinute - startMinute < 5)
+    ) {
+      return res.render("tutorIndex", {
+        error: "Appointment must be at least 5 minutes long.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // session can only be an hour max long
+    if (
+      endHour - startHour > 1 ||
+      (endHour - startHour === 1 && endMinute > startMinute)
+    ) {
+      return res.render("tutorIndex", {
+        error: "Appointment can only be an hour long maximum.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // update the times for specific appointment
+    const appointmentUpdated = await Appointment.findOneAndUpdate(
+      { _id: appointmentId },
+      {
+        $set: {
+          "attendance.actualStart": sessionStartTime,
+          "attendance.actualEnd": sessionEndTime,
+        },
+      },
+    );
+
+    // appointment unable to update
+    if (!appointmentUpdated) {
+      return res.render("tutorIndex", {
+        error: "Appointment could not be updated.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // re-render tutor page
+    res.render("tutorIndex", {
+      error: null,
+      shiftError,
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: false,
+      upcomingTutorShifts,
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: false,
+    });
+  } catch (err) {
+    res.render("tutorIndex", {
+      error: "Failed to load tutor index page.",
+      shiftError: null,
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: false,
+      upcomingTutorShifts: [],
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: false,
+    });
+  }
+};
 
 // POST: update submitted show/now show in MongoDB for specific tutor appointment selected
 exports.submitShow = async (req, res) => {
-    try {
-        // if not an auth user, send to login page
-        if (!req.session.user) {
-            return res.render('login',
-            {
-                title: 'Login Page',
-                cssStylesheet: 'login.css',
-                jsFile: 'login.js',
-                error: "User not logged in.",
-                user: null
-            });
-        }
-
-        // if auth user but not a tutor, send to login page
-        if (req.session.user.role !== "tutor") {
-            return res.render('login',
-            {
-                title: 'Login Page',
-                cssStylesheet: 'login.css',
-                jsFile: 'login.js',
-                error: "Access denied. Only tutors can view this page.",
-                user: null
-            });
-        }
-
-        const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
-        // function to get all shifts for the tutor and sort by date and time
-        let upcomingTutorShifts = [];
-        let shiftError = null;
-        try {
-            upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
-        } catch (err) {
-            shiftError = "Failed to load upcoming tutor shifts.";
-        }
-
-
-        // get appointment id and show value
-        const appointmentId = req.body.selectedAppointment;
-        const isShow = req.body['select-show'];
-
-        // if isShow not entered
-        if (!isShow) {
-            return res.render('tutorIndex', {
-                error: "Required to enter show/no show.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // no appointment selected
-        if (!appointmentId) {
-            return res.render('tutorIndex', {
-                error: "No appointment selected.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // change to the proper value needed in MongoDB
-        let updateValue;
-        if (isShow === "no-show") {
-            updateValue = "noShow";
-        } else if (isShow === "show") {
-            updateValue = "attended";
-        } else {
-            return res.render('tutorIndex', {
-                error: "Invalid show or no-show value.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // update the show/no show for specific appointment
-        const appointmentExist = await Appointment.findOneAndUpdate({ _id: appointmentId }, { $set: { "attendance.attendanceStatus": updateValue } });
-
-        // no appointment found
-        if (!appointmentExist) {
-            return res.render('tutorIndex', {
-                error: "Appointment not found.",
-                shiftError,
-                title: 'Tutor Appointments',
-                cssStylesheet: 'tutorStyle.css',
-                jsFile: 'tutorScript.js',
-                user: req.session.user,
-                bookedAppointments: [],
-                appointmentsLoaded: false,
-                upcomingTutorShifts,
-                pastBookedAppointments: [],
-                pastAppointmentsLoaded: false
-            });
-        }
-
-        // re-render tutor page
-        res.render('tutorIndex', {
-            error: null,
-            shiftError,
-            title: 'Tutor Appointments',
-            cssStylesheet: 'tutorStyle.css',
-            jsFile: 'tutorScript.js',
-            user: req.session.user,
-            bookedAppointments: [],
-            appointmentsLoaded: false,
-            upcomingTutorShifts,
-            pastBookedAppointments: [],
-            pastAppointmentsLoaded: false
-        });
-    } catch (err) {
-        res.render('tutorIndex', {
-            error: "Failed to load tutor index page.",
-            shiftError: null,
-            title: 'Tutor Appointments',
-            cssStylesheet: 'tutorStyle.css',
-            jsFile: 'tutorScript.js',
-            user: req.session.user,
-            bookedAppointments: [],
-            appointmentsLoaded: false,
-            upcomingTutorShifts: [],
-            pastBookedAppointments: [],
-            pastAppointmentsLoaded: false
-        });
+  try {
+    // if not an auth user, send to login page
+    if (!req.session.user) {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "User not logged in.",
+        user: null,
+      });
     }
-}
+
+    // if auth user but not a tutor, send to login page
+    if (req.session.user.role !== "tutor") {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "Access denied. Only tutors can view this page.",
+        user: null,
+      });
+    }
+
+    const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
+    // function to get all shifts for the tutor and sort by date and time
+    let upcomingTutorShifts = [];
+    let shiftError = null;
+    try {
+      upcomingTutorShifts = await getUpcomingTutorShifts(tutorId);
+    } catch (err) {
+      shiftError = "Failed to load upcoming tutor shifts.";
+    }
+
+    // get appointment id and show value
+    const appointmentId = req.body.selectedAppointment;
+    const isShow = req.body["select-show"];
+
+    // if isShow not entered
+    if (!isShow) {
+      return res.render("tutorIndex", {
+        error: "Required to enter show/no show/pending.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // no appointment selected
+    if (!appointmentId) {
+      return res.render("tutorIndex", {
+        error: "No appointment selected.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // change to the proper value needed in MongoDB
+    let updateValue;
+    if (isShow === "no-show") {
+      updateValue = "noShow";
+    } else if (isShow === "show") {
+      updateValue = "attended";
+    } else if (isShow === "pending") {
+      updateValue = "pending";
+    } else {
+      return res.render("tutorIndex", {
+        error: "Invalid show/no-show/pending value.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // update the show/no show for specific appointment
+    const appointmentExist = await Appointment.findOneAndUpdate(
+      { _id: appointmentId },
+      { $set: { "attendance.attendanceStatus": updateValue } },
+    );
+
+    // no appointment found
+    if (!appointmentExist) {
+      return res.render("tutorIndex", {
+        error: "Appointment not found.",
+        shiftError,
+        title: "Tutor Appointments",
+        cssStylesheet: "tutorStyle.css",
+        jsFile: "tutorScript.js",
+        user: req.session.user,
+        bookedAppointments: [],
+        appointmentsLoaded: false,
+        upcomingTutorShifts,
+        pastBookedAppointments: [],
+        pastAppointmentsLoaded: false,
+      });
+    }
+
+    // re-render tutor page
+    res.render("tutorIndex", {
+      error: null,
+      shiftError,
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: false,
+      upcomingTutorShifts,
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: false,
+    });
+  } catch (err) {
+    res.render("tutorIndex", {
+      error: "Failed to load tutor index page.",
+      shiftError: null,
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: false,
+      upcomingTutorShifts: [],
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: false,
+    });
+  }
+};
+
+// GET: load the page and display the cancelled appointments under specific tutor
+exports.getCancelledAppointments = async (req, res) => {
+  try {
+    // if not an auth user, send to login page
+    if (!req.session.user) {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "User not logged in.",
+        user: null,
+      });
+    }
+
+    // if auth user but not a tutor, send to login page
+    if (req.session.user.role !== "tutor") {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "Access denied. Only tutors can view this page.",
+        user: req.session.user,
+      });
+    }
+
+    const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
+
+    // get any cancelled booked appointments under current tutor user (appointmentStatus is "cancelled")
+    const cancelledAppointments = await Appointment.aggregate([
+      {
+        $lookup: {
+          from: "tutorshifts",
+          localField: "tutorShiftId",
+          foreignField: "_id",
+          as: "tutorShift",
+        },
+      },
+      { $unwind: "$tutorShift" },
+      {
+        $lookup: {
+          from: "users",
+          localField: "studentId",
+          foreignField: "_id",
+          as: "student",
+        },
+      },
+      { $unwind: "$student" },
+      {
+        $match: {
+          "tutorShift.tutorId": tutorId,
+          appointmentStatus: "cancelled",
+        },
+      },
+      {
+        $project: {
+          course: 1,
+          appointmentDate: 1,
+          startTime: 1,
+          endTime: 1,
+          "student.fname": 1,
+          "student.lname": 1,
+        },
+      },
+      { $sort: { appointmentDate: 1, startTime: 1 } },
+    ]);
+
+    // render cancelled page
+    res.render("tutorCancelled", {
+      error: null,
+      title: "Cancelled Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      appointmentsLoaded: true,
+      cancelledAppointments,
+    });
+  } catch (err) {
+    res.render("tutorCancelled", {
+      error: "Failed to load cancelled appointments page.",
+      title: "Cancelled Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      appointmentsLoaded: false,
+      cancelledAppointments: [],
+    });
+  }
+};

--- a/server/routes/tutorRoute.js
+++ b/server/routes/tutorRoute.js
@@ -12,9 +12,6 @@ route.get('/tutorIndex/tutorAppointment', controller.getTutorAppointments);
 // update submitted comment in MongoDB for specific tutor appointment selected
 route.post('/tutorIndex/submitComment', controller.submitComment);
 
-// display specific tutor comments in comments text area if any for appointment selected
-// route.get('/tutorIndex/viewComment', controller.viewComment);
-
 // update submitted start and end times in MongoDB for specific tutor appointment selected
 route.post('/tutorIndex/submitTimes', controller.submitTimes);
 
@@ -25,5 +22,8 @@ route.post('/tutorIndex/submitShow', controller.submitShow);
 route.post("/tutorIndex/tutorAppointment", (req, res) => {
     res.redirect("/tutorIndex/tutorAppointment");
 });
+
+// display the cancelled appointments under specific tutor
+route.get('/tutorCancelled', controller.getCancelledAppointments);
 
 module.exports = route;

--- a/views/includes/_navbar.ejs
+++ b/views/includes/_navbar.ejs
@@ -32,6 +32,7 @@
             </li>
         <% } else if (user && user.role === 'tutor') { %>
             <li><a href="/tutorIndex">Appointments</a></li> <!--To tutor functionality-->
+            <li><a href="/tutorCancelled">Cancelled Appointments</a></li> <!--View cancelled appointments-->
             <li>
                 <form action="/logout" method="POST"> <!--After log out action, get sent to index page-->
                     <button id="logout-tutor-button">Logout Tutor</button>

--- a/views/studentAppointment.ejs
+++ b/views/studentAppointment.ejs
@@ -78,7 +78,6 @@
                         endHourNum = endHourNum % 12 || 12;
                     %>
                     <p><b><%= startHourNum + ":" + startMinute + " " + startAMPM + " - " + endHourNum + ":" + endMinute + " " + endAMPM %></b></p>
-                    <p><%= appointment.appointmentStatus %></p>
                 </div>
             <% }) %>
         <% } %>

--- a/views/tutorCancelled.ejs
+++ b/views/tutorCancelled.ejs
@@ -1,0 +1,55 @@
+<%- include("includes/_header") %>
+
+<% if (error) { %>
+  <div class="alert"><strong>Error:</strong> <%= error %></div>
+<% } %>
+
+<!--Navigation Bar-->
+<header>
+  <%- include("includes/_navbar") %>
+</header>
+
+  <!--Tutor container for appointment functionality-->
+  <div class="tutor-container">
+    <div class="tutor-columns">
+        <div class="tutor-column">
+          <h1>Cancelled Appointments</h1>
+          <div id="tutor-view-cancelled-appointments" class="tutor-view-cancelled-appointments">
+            <br />
+            <% if (!appointmentsLoaded) { %>
+              <p>No cancelled appointments have loaded.</p>
+            <% } else if (!cancelledAppointments || cancelledAppointments.length === 0) { %>
+              <p>You have no cancelled appointments.</p>
+            <% } else { %>
+              <% cancelledAppointments.forEach(appointment => { %>
+                <div class="tutorShiftInfo">
+                  <p><b>Student: <%= appointment.student.fname %> <%= appointment.student.lname %></b></p>
+                  <p><%= appointment.course %></p>
+                  <!--used toUTCString() instead of .toDateString() to get the proper date and slice to look nice-->
+                  <p><%= appointment.appointmentDate.toUTCString().slice(0, 16) %></p>
+                  <!--Display in standard time-->
+                  <% 
+                    const [startHour, startMinute] = appointment.startTime.split(":");
+                    const [endHour, endMinute] = appointment.endTime.split(":");
+
+                    let startHourNum = parseInt(startHour);
+                    let endHourNum = parseInt(endHour);
+
+                    const startAMPM = startHourNum >= 12 ? "PM" : "AM";
+                    const endAMPM = endHourNum >= 12 ? "PM" : "AM";
+
+                    startHourNum = startHourNum % 12 || 12;
+                    endHourNum = endHourNum % 12 || 12;
+                  %> 
+                  <p><b>
+                    <%= startHourNum + ":" + startMinute + " " + startAMPM %> - <%= endHourNum + ":" + endMinute + " " + endAMPM %>
+                  </b></p>
+                  <br />
+                </div> <!-- end of tutor shift info div -->
+              <% }) %>
+            <% } %>
+          </div> <!-- end of tutor view cancelled appointments-->
+    </div> <!-- end of tutor columns -->
+  </div> <!-- end of tutor container -->
+
+<%- include("includes/_footer") %>

--- a/views/tutorIndex.ejs
+++ b/views/tutorIndex.ejs
@@ -47,7 +47,6 @@
               <% } %>
 
             </div> <!-- end of tutor calendar container -->
-
       </div> <!-- end of tutor column for schedule-->
 
 
@@ -70,6 +69,7 @@
             <% } else { %>
               <% bookedAppointments.forEach(appointment => { %>
                 <div class="tutorShiftInfo">
+                  <p><b>Student: <%= appointment.student.fname %> <%= appointment.student.lname %></b></p>
                   <p><%= appointment.course %></p>
                   <!--used toUTCString() instead of .toDateString() to get the proper date and slice to look nice-->
                   <p><%= appointment.appointmentDate.toUTCString().slice(0, 16) %></p>
@@ -91,7 +91,7 @@
                     <%= startHourNum + ":" + startMinute + " " + startAMPM %> - <%= endHourNum + ":" + endMinute + " " + endAMPM %>
                   </b></p>
 
-                  <p><%= appointment.appointmentStatus %></p>
+                  <p>Attendance: <%= appointment.attendance.attendanceStatus === "noShow" ? "no-show" : appointment.attendance.attendanceStatus %></p>
                   <br />
 
                   <input type="radio" name="selectedAppointment" value="<%= appointment._id %>" data-comment='<%= JSON.stringify(appointment.tutorComments || "") %>' data-actual-start="<%= appointment.attendance?.actualStart || '' %>" data-actual-end="<%= appointment.attendance?.actualEnd || '' %>" data-show="<%= appointment.attendance?.attendanceStatus || '' %>" />
@@ -141,6 +141,7 @@
               <option value="" disabled selected hidden>-- Select an Option --</option>
               <option value="show">Show</option>
               <option value="no-show">No-Show</option>
+              <option value="pending">Pending</option>
             </select>
             <br />
             <!--Update comment in backend when submit-->
@@ -169,6 +170,7 @@
                 <% } else { %>
                   <% pastBookedAppointments.forEach(appointment => { %>
                     <div class="tutorShiftInfo">
+                      <p><b>Student: <%= appointment.student.fname %> <%= appointment.student.lname %></b></p>
                       <p><%= appointment.course %></p>
                       <!--used toUTCString() instead of .toDateString() to get the proper date and slice to look nice-->
                       <p><%= appointment.appointmentDate.toUTCString().slice(0, 16) %></p>
@@ -191,7 +193,7 @@
                         <%= startHourNum + ":" + startMinute + " " + startAMPM %> - <%= endHourNum + ":" + endMinute + " " + endAMPM %>
                       </b></p>
                       
-                      <p><%= appointment.appointmentStatus %></p>
+                      <p>Attendance: <%= appointment.attendance.attendanceStatus === "noShow" ? "no-show" : appointment.attendance.attendanceStatus %></p>
                       <br />
 
                       <input type="radio" name="selectedAppointment" value="<%= appointment._id %>" data-comment='<%= JSON.stringify(appointment.tutorComments || "") %>' data-actual-start="<%= appointment.attendance?.actualStart || '' %>" data-actual-end="<%= appointment.attendance?.actualEnd || '' %>" data-show="<%= appointment.attendance?.attendanceStatus || '' %>" />


### PR DESCRIPTION
Tutor now has another navbar link to go to Cancelled Appointments page (ctrl + f + getCancelledAppointments to see the code in the tutorController).

On the tutorIndex page, tutor sees attendance status instead of appointment status for each appointment displayed. Tutor can also now set the status of Show / No-Show back to pending.

Format document the tutorController.