### PR TITLE
Jp login attempts deactivation

### DIFF
--- a/assets/js/login.js
+++ b/assets/js/login.js
@@ -1,39 +1,39 @@
+//MARK: DELETE LATER
+// // EMAIL REGEX
+// // email must be an ilstu.edu address
+// const emailRegex = /^[^\s@]+@ilstu\.edu$/;
 
-// EMAIL REGEX
-// email must be an ilstu.edu address
-const emailRegex = /^[^\s@]+@ilstu\.edu$/;
+// // Validates email is @ilstu.edu email
+// function validateForm(emailId) {
+//     const email = document.getElementById(emailId).value;
+//     // const errorSpan = document.getElementById(emailId + "Error"); 
+//     // let valid = true;
 
-// Validates email is @ilstu.edu email
-function validateForm(emailId) {
-    const email = document.getElementById(emailId).value;
-    const errorSpan = document.getElementById(emailId + "Error"); 
-    let valid = true;
+//     // if (!emailRegex.test(email)) {
+//     //     errorSpan.innerText = "Please enter a valid @ilstu.edu email address.";
+//     //     // valid = false;
+//     // } else {
+//     //     errorSpan.innerText = "";
+//     // }
 
-    if (!emailRegex.test(email)) {
-        errorSpan.innerText = "Please enter a valid @ilstu.edu email address.";
-        valid = false;
-    } else {
-        errorSpan.innerText = "";
-    }
+//     if (!validatePassword()) {
+//         // valid = false;
+//     }
 
-    if (!validatePassword()) {
-        valid = false;
-    }
+//     // return valid;
+// }
 
-    return valid;
-}
+// // Ensures password is at least 8 characters long
+// function validatePassword() {
+//     //const password = document.getElementById("password").value;
+//   //  const passwordError = document.getElementById("passwordError");
 
-// Ensures password is at least 8 characters long
-function validatePassword() {
-    const password = document.getElementById("password").value;
-    const passwordError = document.getElementById("passwordError");
-
-    if (password.length < 8) {
-        passwordError.innerText = "Password must be at least 8 characters long.";
-        return false;
-    } else {
-        passwordError.innerText = "";
-        return true;
-    }
-}
+//     if (password.length < 8) {
+//        //  passwordError.innerText = "Password must be at least 8 characters long.";
+//         return false;
+//     } else {
+//      //   passwordError.innerText = "";
+//         return true;
+//     }
+// }
 

--- a/server/controller/authController.js
+++ b/server/controller/authController.js
@@ -119,8 +119,44 @@ exports.loginUser = async (req, res) => {
     try {
         const user = await User.findOne({ email });
 
-        // make sure password is at least 8 characters long
+        // ensures email is entered and in the form of @ilstu.edu
+        const emailRegex = /^[^\s@]+@ilstu\.edu$/;
+        if (!email || !emailRegex.test(email)) {
+            return res.render('login', {
+                error: 'Email address not in the form of @ilstu.edu.',
+                title: 'Login',
+                cssStylesheet: 'login.css',
+                jsFile: 'login.js',
+                user: null
+            });
+        }
+
+         // make sure password is at least 8 characters long
         if (!password || password.length < 8) {
+            // increment failedAttempts count (for non-admin users only)
+            if (user && user.role !== "admin") {
+                await User.updateOne(
+                    { _id: user._id },
+                    { $inc: { failedAttempts: 1 } }
+                );
+            }
+
+            // if user fails to log in 4 times, deactivate user
+            if (user && user.failedAttempts >= 4) {
+                await User.updateOne(
+                    { _id: user._id },
+                    { $set: { failedAttempts: 0, isActive: false } }
+                );
+
+                return res.render('login', {
+                    error: 'Too many login attempts for this email. Account has been deactivated. Please contact admin to reactive account.',
+                    title: 'Login',
+                    cssStylesheet: 'login.css',
+                    jsFile: 'login.js',
+                    user: null
+                });
+            }
+
             return res.render('login', {
                 error: 'Password must be at least 8 characters long.',
                 title: 'Login',
@@ -132,20 +168,34 @@ exports.loginUser = async (req, res) => {
 
         // checks to see if this user exists or if password doesn't match
         if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
+
+            // increment failedAttempts count (for non-admin users only)
+            if (user && user.role !== "admin") {
+                // increment failedAttempts count
+                await User.updateOne(
+                    { _id: user._id },
+                    { $inc: { failedAttempts: 1 } }
+                );
+            }
+
+            // if user fails to log in 4 times, deactivate user
+            if (user && user.failedAttempts >= 4) {
+                await User.updateOne(
+                    { _id: user._id },
+                    { $set: { failedAttempts: 0, isActive: false } }
+                );
+
+                return res.render('login', {
+                    error: 'Too many login attempts for this email. Account has been deactivated. Please contact admin to reactive account.',
+                    title: 'Login',
+                    cssStylesheet: 'login.css',
+                    jsFile: 'login.js',
+                    user: null
+                });
+            }
+
             return res.render('login', {
                 error: 'Invalid email or password.',
-                title: 'Login',
-                cssStylesheet: 'login.css',
-                jsFile: 'login.js',
-                user: null
-            });
-        }
-
-        // ensures email is entered and in the form of @ilstu.edu
-        const emailRegex = /^[^\s@]+@ilstu\.edu$/;
-        if (!email || !emailRegex.test(email)) {
-            return res.render('login', {
-                error: 'Email address not in the form of @ilstu.edu.',
                 title: 'Login',
                 cssStylesheet: 'login.css',
                 jsFile: 'login.js',
@@ -175,6 +225,12 @@ exports.loginUser = async (req, res) => {
                 user: null
             });
         }
+
+        // successfully able to login, reset count
+        await User.updateOne(
+            { _id: user._id },
+            { $set: { failedAttempts: 0 } }
+        );
 
         // stores user in session
         req.session.user = user;

--- a/server/controller/authController.js
+++ b/server/controller/authController.js
@@ -134,15 +134,17 @@ exports.loginUser = async (req, res) => {
          // make sure password is at least 8 characters long
         if (!password || password.length < 8) {
             // increment failedAttempts count (for non-admin users only)
+            let updatedUser;
             if (user && user.role !== "admin") {
-                await User.updateOne(
-                    { _id: user._id },
-                    { $inc: { failedAttempts: 1 } }
+                updatedUser = await User.findByIdAndUpdate(
+                    { _id: user._id},
+                    { $inc: { failedAttempts: 1 } },
+                    { new: true }
                 );
             }
 
             // if user fails to log in 4 times, deactivate user
-            if (user && user.failedAttempts >= 4) {
+            if (updatedUser && updatedUser.failedAttempts >= 4) {
                 await User.updateOne(
                     { _id: user._id },
                     { $set: { failedAttempts: 0, isActive: false } }
@@ -170,16 +172,17 @@ exports.loginUser = async (req, res) => {
         if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
 
             // increment failedAttempts count (for non-admin users only)
+            let updatedUser;
             if (user && user.role !== "admin") {
-                // increment failedAttempts count
-                await User.updateOne(
-                    { _id: user._id },
-                    { $inc: { failedAttempts: 1 } }
+                updatedUser = await User.findByIdAndUpdate(
+                    { _id: user._id},
+                    { $inc: { failedAttempts: 1 } },
+                    { new: true }
                 );
             }
 
             // if user fails to log in 4 times, deactivate user
-            if (user && user.failedAttempts >= 4) {
+            if (updatedUser && updatedUser.failedAttempts >= 4) {
                 await User.updateOne(
                     { _id: user._id },
                     { $set: { failedAttempts: 0, isActive: false } }

--- a/server/model/userModel.js
+++ b/server/model/userModel.js
@@ -8,6 +8,7 @@ const userSchema = new mongoose.Schema(
         passwordHash: { type: String, required: true, minlength: 8 },
         isActive: { type: Boolean, default: true },
         googleTokens: { type: Object, default: null},
+        failedAttempts: { type: Number, default: 0 },
         // only for tutors, references courses they can tutor
         tutorCourses: {
             type: [{ type: mongoose.Schema.Types.ObjectId, ref: "Course" }],

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -11,15 +11,13 @@
 
   <div class="loginBox">
     <h1>Login</h1>
-    <form action="/login" method="post" onsubmit="return validateForm('email')">
+    <form action="/login" method="post">
       <label for="email">Email:</label>
       <input type="text" id="email" name="email" required >
-      <span id="emailError" style="color: red; font-size: 0.8em; display: block; margin-top: 1px;"></span>
       <br><br>
 
       <label for="password">Password:</label>
       <input type="password" id="password" name="password" required >
-      <span id="passwordError" style="color: red; font-size: 0.8em; display: block; margin-top: 1px;"></span>
       <br><br>
 
       <button type="submit">Login</button><br><br>


### PR DESCRIPTION
Users now have 4 attempts to enter the correct password for a specific user email. If fail to sign in, account will deactivate and admin would have to reactivate the account. If correctly enters password before the fourth attempt, the failedAttempts field in User schema **(a new field in the schema)** will reset to 0 (does the same once the user gets deactivated).

Unfortunately, I had to get rid of return onsubmit="validateForm('email')" and the frontend JavaScript behind it because it was not secure (users can change the frontend JS) and already uses the same code in the backend. It was also removed because the database increments would not occur otherwise since the JS cuts it off before reaching the backend (and we don't want to do this in the frontend JS too because of security reasons). I also had to get rid of the error spans because they would glitch out from the page re-rendering, but the proper error messages still display at the top of the page and do not glitch out. We can prettify those later if we want to.

Login.js is no longer needed but we should keep it a bit longer just in case we end up using it in the future. Otherwise, the code and potentially the file itself will get deleted.