### PR TITLE
Jp user change password

### DIFF
--- a/assets/js/studentScript.js
+++ b/assets/js/studentScript.js
@@ -28,15 +28,32 @@
 
 
 // js for when student cancels an appointment under "Upcoming Appointments"
-  const confirmCancelModal = document.getElementById("confirmCancelModal");
-  const closeConfirmBtn = document.getElementById("closeConfirmBtn");
-  const studentCancelForm = document.getElementById("studentCancelForm");
+const confirmCancelModal = document.getElementById("confirmCancelModal");
+const closeConfirmBtn = document.getElementById("closeConfirmBtn");
+const studentCancelForm = document.getElementById("studentCancelForm");
 
-  function openStudentCancelModal(appointmentId) {
-    studentCancelForm.action = `/studentAppointment/cancel/${appointmentId}`;
-    confirmCancelModal.style.display = "block";
+function openStudentCancelModal(appointmentId) {
+  studentCancelForm.action = `/studentAppointment/cancel/${appointmentId}`;
+  confirmCancelModal.style.display = "block";
+}
+
+closeConfirmBtn.addEventListener("click", function () {
+  confirmCancelModal.style.display = "none";
+});
+
+
+
+// clears password fields
+const clearPasswordButton = document.getElementById("clear-password-button");
+
+clearPasswordButton.addEventListener("click", ()=> {
+  const passwordInput = document.querySelector('input[name="password"]');
+  const confirmPasswordInput = document.querySelector('input[name="confirmPassword"]');
+
+  if (passwordInput) { 
+      passwordInput.value = "";
   }
-
-  closeConfirmBtn.addEventListener("click", function () {
-    confirmCancelModal.style.display = "none";
-  });
+  if (confirmPasswordInput) { 
+      confirmPasswordInput.value = "";
+  }
+});

--- a/assets/js/tutorScript.js
+++ b/assets/js/tutorScript.js
@@ -16,6 +16,7 @@ const showLabel = document.getElementById("show-label");
 const selectShow = document.getElementById("select-show");
 const cancelButton = document.getElementById("cancel-button");
 const appointmentRadios = document.querySelectorAll('input[name="selectedAppointment"]');
+const clearPasswordButton = document.getElementById("clear-password-button");
 
 
 /*Add event listener for each radio button, when change a radio button it makes button options visible*/
@@ -174,5 +175,19 @@ cancelButton.addEventListener("click", ()=> {
 
     if (selectedAppointment) {
         selectedAppointment.checked = false;
+    }
+});
+
+
+// clears password fields
+clearPasswordButton.addEventListener("click", ()=> {
+    const passwordInput = document.querySelector('input[name="password"]');
+    const confirmPasswordInput = document.querySelector('input[name="confirmPassword"]');
+
+    if (passwordInput) { 
+        passwordInput.value = "";
+    }
+    if (confirmPasswordInput) { 
+        confirmPasswordInput.value = "";
     }
 });

--- a/server/controller/adminController.js
+++ b/server/controller/adminController.js
@@ -2341,7 +2341,7 @@ exports.addUser = async (req, res) => {
       return res.redirect("/adminAuditLog");
     }
 
-    // FIX LATER, ADD FOR STUDENT?? SOURCEPAGE ERROR
+    
     // Security check to make sure that emails will not be dupliated
     // (if a diff user already has email, return the 400/cannot process req)
     const existingUser = await User.findOne({ email: email });

--- a/server/controller/adminController.js
+++ b/server/controller/adminController.js
@@ -1,6 +1,6 @@
 const Appointment = require("../model/appointmentModel");
 const { sendEmail } = require("../services/emailService");
-const { adminCancellationTemplate } = require("../../views/templates/emailTemplates");
+const { adminCancellationTemplate, accountCreatedTemplate } = require("../../views/templates/emailTemplates");
 const User = require("../model/userModel");
 const Course = require("../model/courseModel");
 const TutorShift = require("../model/tutorShiftModel");
@@ -2454,6 +2454,40 @@ exports.addUser = async (req, res) => {
         details: `New student ${fname} ${lname} added. Status: active.`,
       });
     }
+
+
+    // send email to new user email that account was created and temporary password set by admin was sent and CC admin
+    let emailSent = false;
+    try {
+      await sendEmail({
+        to: email,
+        cc: process.env.GMAIL_ADMIN, // CC admin
+        subject: "Account Created",
+        html: accountCreatedTemplate({
+          name: fname,
+          date: new Date().toLocaleString("en-US"),
+          password: password,
+        })
+      });
+      emailSent = true;
+      
+    } catch (emailErr) {
+      console.error("Admin account creation email sending error.");
+    }
+
+    // log if email failed to send
+    if (!emailSent) {
+      try {
+        await NotificationLog.create({
+          recipientUserId: newUser._id,
+          appointmentDate: new Date(),
+          notificationType: "SEND_EMAIL_FAILED",
+        });
+      } catch (err) {
+        console.error("NotificationLog SEND_EMAIL_FAILED for admin create account failed.");
+      }
+    }
+
 
     // redirect back to the correct page after creating the user
     if (role === "student") {

--- a/server/controller/appointmentController.js
+++ b/server/controller/appointmentController.js
@@ -1,11 +1,12 @@
 const { sendEmail } = require("../services/emailService");
-const { confirmationTemplate } = require("../../views/templates/emailTemplates");
+const { confirmationTemplate, passwordChangeTemplate } = require("../../views/templates/emailTemplates");
 const Appointment = require("../model/appointmentModel");
 const TutorShift = require("../model/tutorShiftModel");
 const mongoose = require("mongoose");
 const NotificationLog = require("../model/notificationLog");
 const { createCalendarEvent } = require("../services/calendarService");
 const User = require("../model/userModel");
+const bcrypt = require("bcrypt");
 const { formatTo12Hour } = require("../services/timeService");
 
 
@@ -405,6 +406,133 @@ exports.getBookedAppointments = async (req, res) => {
       cssStylesheet: "studentStyle.css",
       jsFile: "studentScript.js",
       error: "Failed to view appointments.",
+      user: req.session.user,
+      availableShifts: [],
+      bookedAppointments: [],
+      pastBookedAppointments: [],
+      formatTo12Hour
+    });
+  }
+};
+
+
+exports.changePassword = async (req, res) => {
+  try {
+    // if not an auth user, send to login page
+    if (!req.session.user) {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "User not logged in.",
+        user: null,
+      });
+    }
+
+    // if auth user but not a student, send to login page
+    if (req.session.user.role !== "student") {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "Access denied. Only students can view this page.",
+        user: req.session.user,
+      });
+    }
+
+    // get entered passwords, studentId, and student information
+    const { password, confirmPassword } = req.body;
+    const studentId = new mongoose.Types.ObjectId(req.session.user._id);
+    const student = await User.findById(studentId);
+
+    // Student not found
+    if (!student) {
+      req.session.error = "Student not found.";
+      return res.redirect("/studentAppointment");
+    }
+
+    // get student email and first name
+    const email = student.email;
+    const fname = student.fname;
+
+    // make sure all fields were filled out
+    if (!password || !confirmPassword) {
+      req.session.error = "All fields are required.";
+      return res.redirect("/studentAppointment");
+    }
+
+    // make sure password is at least 8 characters long
+    if (password.length < 8) {
+      req.session.error = "Password must be at least 8 characters long.";
+      return res.redirect("/studentAppointment");
+    }
+
+    // password cannot contain spaces
+    if (password.includes(" ")) {
+      req.session.error = "Password cannot contain spaces.";
+      return res.redirect("/studentAppointment");
+    }
+
+    // password must only contain any of the following: A-Z, a-z, 0-9, and !@#$%^&*
+    const passwordRegex = /^[A-Za-z0-9!@#$%^&*]+$/;
+      if (!passwordRegex.test(password)) {
+        req.session.error = "Password must not contain spaces, special characters, or Unicode characters. Can only use the following: A-Z, a-z, 0-9, and !@#$%^&*";
+        return res.redirect("/studentAppointment");
+    }
+
+    // password and confirm password
+    if (password !== confirmPassword) {
+      req.session.error = "Password and Confirm Password must be the same.";
+      return res.redirect("/studentAppointment");
+    }
+    
+    // hashing the passwords
+    const saltRounds = 10;
+    const passwordHash = await bcrypt.hash(password, saltRounds);
+
+    // save the hashed password
+    student.passwordHash = passwordHash;
+    await student.save();
+
+    // send email to user email that account password was changed and CC admin
+    let emailSent = false;
+    try {
+      await sendEmail({
+        to: email,
+        cc: process.env.GMAIL_ADMIN, // CC admin
+        subject: "Account Password Changed",
+        html: passwordChangeTemplate({
+          name: fname,
+          date: new Date().toLocaleString("en-US")
+        })
+      });
+      emailSent = true;
+    } catch (emailErr) {
+      console.error("User password change email sending error.");
+    }
+
+    // log if email failed to send
+    if (!emailSent) {
+      try {
+        await NotificationLog.create({
+          recipientUserId: tutor._id,
+          appointmentDate: new Date(),
+          notificationType: "SEND_EMAIL_FAILED",
+        });
+      } catch (err) {
+        console.error("NotificationLog SEND_EMAIL_FAILED for user change password failed.");
+      }
+    }
+
+    return res.redirect("/studentAppointment");
+
+  } catch (err) {
+    // in case of any errors, can log them and 500 for unfulfilled req
+    return res.status(500).render("studentAppointment", {
+      title: "Book an Appointment",
+      cssStylesheet: "studentStyle.css",
+      jsFile: "studentScript.js",
+      error: "Unable to change user password.",
       user: req.session.user,
       availableShifts: [],
       bookedAppointments: [],

--- a/server/controller/tutorController.js
+++ b/server/controller/tutorController.js
@@ -733,3 +733,8 @@ exports.getCancelledAppointments = async (req, res) => {
     });
   }
 };
+
+
+exports.changePassword = async (req, res) => {
+  
+};

--- a/server/controller/tutorController.js
+++ b/server/controller/tutorController.js
@@ -1,6 +1,10 @@
 const TutorShift = require("../model/tutorShiftModel");
 const Appointment = require("../model/appointmentModel");
 const centerOpen = require("../model/centerOpenSchedule");
+const User = require("../model/userModel");
+const { sendEmail } = require("../services/emailService");
+const { passwordChangeTemplate } = require("../../views/templates/emailTemplates");
+const bcrypt = require("bcrypt");
 const { formatTo12Hour } = require("../services/timeService");
 const mongoose = require("mongoose");
 
@@ -643,6 +647,136 @@ exports.submitShow = async (req, res) => {
 };
 
 
+exports.changePassword = async (req, res) => {
+  try {
+    // if not an auth user, send to login page
+    if (!req.session.user) {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "User not logged in.",
+        user: null,
+      });
+    }
+
+    // if auth user but not a tutor, send to login page
+    if (req.session.user.role !== "tutor") {
+      return res.render("login", {
+        title: "Login Page",
+        cssStylesheet: "login.css",
+        jsFile: "login.js",
+        error: "Access denied. Only tutors can view this page.",
+        user: req.session.user,
+      });
+    }
+
+    // get entered passwords, tutorId, and tutor information
+    const { password, confirmPassword } = req.body;
+    const tutorId = new mongoose.Types.ObjectId(req.session.user._id);
+    const tutor = await User.findById(tutorId);
+
+    // Tutor not found
+    if (!tutor) {
+      req.session.error = "Tutor not found.";
+      return res.redirect("/tutorIndex");
+    }
+
+    // get tutor email and first name
+    const email = tutor.email;
+    const fname = tutor.fname;
+
+    // make sure all fields were filled out
+    if (!password || !confirmPassword) {
+      req.session.error = "All fields are required.";
+      return res.redirect("/tutorIndex");
+    }
+
+    // make sure password is at least 8 characters long
+    if (password.length < 8) {
+      req.session.error = "Password must be at least 8 characters long.";
+      return res.redirect("/tutorIndex");
+    }
+
+    // password cannot contain spaces
+    if (password.includes(" ")) {
+      req.session.error = "Password cannot contain spaces.";
+      return res.redirect("/tutorIndex");
+    }
+
+    // password must only contain any of the following: A-Z, a-z, 0-9, and !@#$%^&*
+    const passwordRegex = /^[A-Za-z0-9!@#$%^&*]+$/;
+      if (!passwordRegex.test(password)) {
+        req.session.error = "Password must not contain spaces, special characters, or Unicode characters. Can only use the following: A-Z, a-z, 0-9, and !@#$%^&*";
+        return res.redirect("/tutorIndex");
+    }
+
+    // password and confirm password
+    if (password !== confirmPassword) {
+      req.session.error = "Password and Confirm Password must be the same.";
+      return res.redirect("/tutorIndex");
+    }
+    
+    // hashing the passwords
+    const saltRounds = 10;
+    const passwordHash = await bcrypt.hash(password, saltRounds);
+
+    // save the hashed password
+    tutor.passwordHash = passwordHash;
+    await tutor.save();
+
+    // send email to user email that account password was changed and CC admin
+    let emailSent = false;
+    try {
+      await sendEmail({
+        to: email,
+        cc: process.env.GMAIL_ADMIN, // CC admin
+        subject: "Account Password Changed",
+        html: passwordChangeTemplate({
+          name: fname,
+          date: new Date().toLocaleString("en-US")
+        })
+      });
+      emailSent = true;
+    } catch (emailErr) {
+      console.error("User password change email sending error.");
+    }
+
+    // log if email failed to send
+    if (!emailSent) {
+      try {
+        await NotificationLog.create({
+          recipientUserId: tutor._id,
+          appointmentDate: new Date(),
+          notificationType: "SEND_EMAIL_FAILED",
+        });
+      } catch (err) {
+        console.error("NotificationLog SEND_EMAIL_FAILED for user change password failed.");
+      }
+    }
+
+    return res.redirect("/tutorIndex");
+
+  } catch (err) {
+    // in case of any errors, can log them and 500 for unfulfilled req
+    return res.status(500).render("tutorIndex", {
+      error: "Unable to change user password.",
+      shiftError: null,
+      title: "Tutor Appointments",
+      cssStylesheet: "tutorStyle.css",
+      jsFile: "tutorScript.js",
+      user: req.session.user,
+      bookedAppointments: [],
+      appointmentsLoaded: false,
+      upcomingTutorShifts: [],
+      pastBookedAppointments: [],
+      pastAppointmentsLoaded: false,
+      formatTo12Hour
+    });
+  }
+};
+
+
 // GET: load the page and display the cancelled appointments under specific tutor
 exports.getCancelledAppointments = async (req, res) => {
   try {
@@ -734,7 +868,3 @@ exports.getCancelledAppointments = async (req, res) => {
   }
 };
 
-
-exports.changePassword = async (req, res) => {
-  
-};

--- a/server/routes/appointmentRoute.js
+++ b/server/routes/appointmentRoute.js
@@ -34,4 +34,7 @@ route.post('/bookAppointment', bookingLimiter, controller.bookAppointment);
 // display the student's booked appointments
 route.get('/studentAppointment', controller.getBookedAppointments);
 
+// change password on submit
+route.post('/changePassword', controller.changePassword);
+
 module.exports = route;

--- a/server/routes/tutorRoute.js
+++ b/server/routes/tutorRoute.js
@@ -22,11 +22,11 @@ route.post('/tutorIndex/submitShow', controller.submitShow);
 route.post("/tutorIndex", (req, res) => {
     res.redirect("/tutorIndex");
 });
-// route.post("/tutorIndex/tutorAppointment", (req, res) => {
-//     res.redirect("/tutorIndex/tutorAppointment");
-// });
-
 // display the cancelled appointments under specific tutor
 route.get('/tutorCancelled', controller.getCancelledAppointments);
+
+// change password on submit
+route.post('/changePassword', controller.changePassword);
+
 
 module.exports = route;

--- a/views/studentAppointment.ejs
+++ b/views/studentAppointment.ejs
@@ -17,7 +17,29 @@
 <!--Display student's booked appointments if any-->
 <div class="mainContent">
     
-    <!--div here that is right-aligned for change password-->
+    <!--right-aligned div for change password-->
+    <div style="display: flex; justify-content: flex-end;">
+        <div class="change-password">
+        <br />
+        <!-- This button will change the visibility of the content -->
+        <button type="button" id="change-password-button" class="small-red-button-round">Change Password</button>
+        <br />
+        <h2 class = "headingText">Change Password</h2>
+        <form action="/changePassword" method="POST">
+            <label class = "modalText" >Password:</label>
+            <input type="password" name="password"  class = "inputFunc" >
+            <span id="passwordError" style="color: red; font-size: 0.8em; display: block; margin-top: 1px;"></span>
+            <br />
+            <label class = "modalText" >Confirm Password:</label>
+            <input type="password" name="confirmPassword"  class = "inputFunc" >
+
+            <br /><br />
+            <button type="submit" class="small-red-button-round">Submit Changes</button>
+            <br>
+            <button type="button" id="clear-password-button" class = "small-red-button-round">Clear Password Fields</button>
+        </form>
+        </div>
+    </div>
 
 
     <div class="contentContainer">

--- a/views/studentAppointment.ejs
+++ b/views/studentAppointment.ejs
@@ -16,6 +16,10 @@
 
 <!--Display student's booked appointments if any-->
 <div class="mainContent">
+    
+    <!--div here that is right-aligned for change password-->
+
+
     <div class="contentContainer">
         <h1>Upcoming Appointments</h1>
         <% if (!bookedAppointments || bookedAppointments.length === 0) { %>

--- a/views/templates/emailTemplates.js
+++ b/views/templates/emailTemplates.js
@@ -71,5 +71,15 @@ function accountCreatedTemplate({ name, date, password }) {
 }
 
 
+function passwordChangeTemplate({ name, date }) {
+  return `
+    <p>Hi ${name},</p>
+    <p>Your account password has been changed.</b></p>
+    <p>If this change was not intentional, please contact an administrator.</p>
 
-module.exports = { confirmationTemplate, studentCancellationTemplate, adminCancellationTemplate, accountDeactivationTemplate, accountCreatedTemplate };
+    <p><b>Date & Time:</b> ${date}<br/></p>
+  `;
+}
+
+
+module.exports = { confirmationTemplate, studentCancellationTemplate, adminCancellationTemplate, accountDeactivationTemplate, accountCreatedTemplate, passwordChangeTemplate };

--- a/views/templates/emailTemplates.js
+++ b/views/templates/emailTemplates.js
@@ -59,4 +59,17 @@ function accountDeactivationTemplate({ name, date }) {
 }
 
 
-module.exports = { confirmationTemplate, studentCancellationTemplate, adminCancellationTemplate, accountDeactivationTemplate };
+function accountCreatedTemplate({ name, date, password }) {
+  return `
+    <p>Hi ${name},</p>
+    <p>Your account has been created.</b></p>
+    <p>Your temporary password is <b>${password}</b>.</p>
+    <p>Please log into your account and set a new password.</p>
+
+    <p><b>Date & Time:</b> ${date}<br/></p>
+  `;
+}
+
+
+
+module.exports = { confirmationTemplate, studentCancellationTemplate, adminCancellationTemplate, accountDeactivationTemplate, accountCreatedTemplate };

--- a/views/tutorIndex.ejs
+++ b/views/tutorIndex.ejs
@@ -12,6 +12,28 @@
 <!--BEGIN REWORK-->
 <main>
 <div class = "tutor-container">
+  <!--div here that is right-aligned for change password-->
+
+  <!--add a button to make stuff visible and not visible-->
+  <div style="display: flex; justify-content: flex-end;">
+    <div class="change-password">
+      <h2 class = "headingText">Change Password Here</h2>
+      <form action="/changePassword" method="POST">
+        <label class = "modalText" >Password:</label>
+        <input type="password" name="password"  class = "inputFunc" >
+        <span id="passwordError" style="color: red; font-size: 0.8em; display: block; margin-top: 1px;"></span>
+        <br />
+        <label class = "modalText" >Confirm Password:</label>
+        <input type="password" name="confirmPassword"  class = "inputFunc" >
+
+        <br /><br />
+        <button type="submit" class = "small-red-button-round">Submit Changes</button>
+        <br>
+        <button type="clear" class = "small-red-button-round">Clear Password Fields</button>
+      </form>
+    </div>
+  </div>
+
   <div class = "schedule-container">
     <h1 style="text-align: center; width: 100%;">Schedule</h1>
     <% if (shiftError) { %>

--- a/views/tutorIndex.ejs
+++ b/views/tutorIndex.ejs
@@ -9,15 +9,17 @@
   <%- include("includes/_navbar") %>
 </header>
 
-<!--BEGIN REWORK-->
+
 <main>
 <div class = "tutor-container">
-  <!--div here that is right-aligned for change password-->
-
-  <!--add a button to make stuff visible and not visible-->
+  <!--right-aligned div for change password-->
   <div style="display: flex; justify-content: flex-end;">
     <div class="change-password">
-      <h2 class = "headingText">Change Password Here</h2>
+      <br />
+      <!-- This button will change the visibility of the content -->
+      <button type="button" id="change-password-button" class="small-red-button-round">Change Password</button>
+      <br />
+      <h2 class = "headingText">Change Password</h2>
       <form action="/changePassword" method="POST">
         <label class = "modalText" >Password:</label>
         <input type="password" name="password"  class = "inputFunc" >
@@ -27,9 +29,9 @@
         <input type="password" name="confirmPassword"  class = "inputFunc" >
 
         <br /><br />
-        <button type="submit" class = "small-red-button-round">Submit Changes</button>
+        <button type="submit" class="small-red-button-round">Submit Changes</button>
         <br>
-        <button type="clear" class = "small-red-button-round">Clear Password Fields</button>
+        <button type="button" id="clear-password-button" class = "small-red-button-round">Clear Password Fields</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
- accountCreatedTemplate and passwordChangeTemplate email templates added for sending temporary password on account creation and for informing the user that their password has been changed
- When admin adds a new user using the addUser function, "temporary password" is now sent to the student or tutor's email
- From there, a tutor or student can use that email to log in and change their password on either the tutorIndex or studentAppointment page
- Passwords follow the same requirements as before, and are still hashed and salted (using bcrypt) before being saved in the database
- When the user is typing a password, they can also click the "Clear Password Fields" button to clear both Password and Confirm Password fields in case they wanted to start over
- An email is sent to the user when their account password has been changed
- **NOTE:** @a-monet was requested to add a modal to both the studentAppointment and tutorIndex pages so when user clicks "Change Password", the content appears in a pop up, and disappears on "Submit Changes"